### PR TITLE
CLOWNFISH-30 Kill callbacks.h

### DIFF
--- a/compiler/c/cfc.c
+++ b/compiler/c/cfc.c
@@ -243,7 +243,6 @@ main(int argc, char **argv) {
     c_binding = CFCC_new(hierarchy, header, footer);
     CFCC_write_hostdefs(c_binding);
     if (args.num_source_dirs != 0) {
-        CFCC_write_callbacks(c_binding);
         CFCC_write_html_docs(c_binding);
         CFCC_write_man_pages(c_binding);
     }

--- a/compiler/go/cfc/cfc.go
+++ b/compiler/go/cfc/cfc.go
@@ -152,10 +152,6 @@ func (obj *BindC) finalize() {
 	C.CFCBase_decref((*C.CFCBase)(unsafe.Pointer(obj.ref)))
 }
 
-func (obj *BindC) WriteCallbacks() {
-	C.CFCC_write_callbacks(obj.ref)
-}
-
 func (obj *BindC) WriteHostDefs() {
 	C.CFCC_write_hostdefs(obj.ref)
 }

--- a/compiler/src/CFCBindCore.c
+++ b/compiler/src/CFCBindCore.c
@@ -506,7 +506,6 @@ S_write_parcel_c(CFCBindCore *self, CFCParcel *parcel) {
         "\n"
         "%s"
         "\n"
-        "#include \"callbacks.h\"\n"
         "#include \"Clownfish/Class.h\"\n"   // Needed for bootstrap.
         "%s\n"
         "\n"

--- a/compiler/src/CFCC.c
+++ b/compiler/src/CFCC.c
@@ -81,13 +81,6 @@ CFCC_destroy(CFCC *self) {
     CFCBase_destroy((CFCBase*)self);
 }
 
-/* Write "callbacks.h" with NULL callbacks.
- */
-void
-CFCC_write_callbacks(CFCC *self) {
-    return;
-}
-
 static char*
 S_callback_decs(CFCClass *klass) {
     CFCMethod **fresh_methods = CFCClass_fresh_methods(klass);

--- a/compiler/src/CFCC.c
+++ b/compiler/src/CFCC.c
@@ -85,47 +85,7 @@ CFCC_destroy(CFCC *self) {
  */
 void
 CFCC_write_callbacks(CFCC *self) {
-    CFCHierarchy  *hierarchy   = self->hierarchy;
-    CFCClass     **ordered     = CFCHierarchy_ordered_classes(hierarchy);
-    char          *all_cb_decs = CFCUtil_strdup("");
-
-    for (int i = 0; ordered[i] != NULL; i++) {
-        CFCClass *klass = ordered[i];
-
-        if (!CFCClass_included(klass)) {
-            char *cb_decs = S_callback_decs(klass);
-            all_cb_decs = CFCUtil_cat(all_cb_decs, cb_decs, NULL);
-            FREEMEM(cb_decs);
-        }
-    }
-
-    FREEMEM(ordered);
-
-    const char pattern[] =
-        "%s\n"
-        "#ifndef CFCCALLBACKS_H\n"
-        "#define CFCCALLBACKS_H 1\n"
-        "\n"
-        "#include <stddef.h>\n"
-        "\n"
-        "%s"
-        "\n"
-        "#endif /* CFCCALLBACKS_H */\n"
-        "\n"
-        "%s\n"
-        "\n";
-    char *file_content = CFCUtil_sprintf(pattern, self->c_header, all_cb_decs,
-                                         self->c_footer);
-
-    // Unlink then write file.
-    const char *inc_dest = CFCHierarchy_get_include_dest(hierarchy);
-    char *filepath = CFCUtil_sprintf("%s" CHY_DIR_SEP "callbacks.h", inc_dest);
-    remove(filepath);
-    CFCUtil_write_file(filepath, file_content, strlen(file_content));
-    FREEMEM(filepath);
-
-    FREEMEM(all_cb_decs);
-    FREEMEM(file_content);
+    return;
 }
 
 static char*
@@ -219,6 +179,8 @@ CFCC_write_hostdefs(CFCC *self) {
         "\n"
         "#define CFISH_OBJ_HEAD \\\n"
         "    size_t refcount;\n"
+        "\n"
+        "#define CFISH_NO_DYNAMIC_OVERRIDES\n"
         "\n"
         "#endif /* H_CFISH_HOSTDEFS */\n"
         "\n"

--- a/compiler/src/CFCC.h
+++ b/compiler/src/CFCC.h
@@ -46,11 +46,6 @@ CFCC_init(CFCC *self, struct CFCHierarchy *hierarchy, const char *header,
 void
 CFCC_destroy(CFCC *self);
 
-/** Write the "callbacks.h" header file with dummy callbacks.
- */
-void
-CFCC_write_callbacks(CFCC *self);
-
 /** Write the "cfish_hostdefs.h" header file.
  */
 void

--- a/runtime/go/build.go
+++ b/runtime/go/build.go
@@ -122,7 +122,6 @@ func runCFC() {
 	modified := coreBinding.WriteAllModified(false)
 	if modified {
 		cBinding := cfc.NewBindC(hierarchy, autogenHeader, "")
-		cBinding.WriteCallbacks()
 		cBinding.WriteHostDefs()
 		hierarchy.WriteLog()
 	}


### PR DESCRIPTION
Refactor CFC internals to eliminate an autogenerated file and centralize some code generation rather than perform generation per-host.

This fixes CLOWNFISH-30.