### PR TITLE
CLOWNFISH-32 can_be_bound

### DIFF
--- a/compiler/src/CFCFunction.c
+++ b/compiler/src/CFCFunction.c
@@ -27,6 +27,7 @@
 #include "CFCParcel.h"
 #include "CFCType.h"
 #include "CFCParamList.h"
+#include "CFCVariable.h"
 #include "CFCDocuComment.h"
 #include "CFCUtil.h"
 
@@ -95,6 +96,28 @@ CFCFunction_destroy(CFCFunction *self) {
     CFCBase_decref((CFCBase*)self->param_list);
     CFCBase_decref((CFCBase*)self->docucomment);
     CFCSymbol_destroy((CFCSymbol*)self);
+}
+
+int
+CFCFunction_can_be_bound(CFCFunction *self) {
+    // Test whether parameters can be mapped automatically.
+    CFCVariable **arg_vars = CFCParamList_get_variables(self->param_list);
+    for (size_t i = 0; arg_vars[i] != NULL; i++) {
+        CFCType *type = CFCVariable_get_type(arg_vars[i]);
+        if (!CFCType_is_object(type) && !CFCType_is_primitive(type)) {
+            return false;
+        }
+    }
+
+    // Test whether return type can be mapped automatically.
+    if (!CFCType_is_void(self->return_type)
+        && !CFCType_is_object(self->return_type)
+        && !CFCType_is_primitive(self->return_type)
+    ) {
+        return false;
+    }
+
+    return true;
 }
 
 CFCType*

--- a/compiler/src/CFCFunction.h
+++ b/compiler/src/CFCFunction.h
@@ -78,6 +78,11 @@ CFCFunction_init(CFCFunction *self, struct CFCParcel *parcel,
 void
 CFCFunction_destroy(CFCFunction *self);
 
+/** Test whether bindings can be generated for a function.
+  */
+int
+CFCFunction_can_be_bound(CFCFunction *function);
+
 struct CFCType*
 CFCFunction_get_return_type(CFCFunction *self);
 

--- a/compiler/src/CFCMethod.c
+++ b/compiler/src/CFCMethod.c
@@ -261,6 +261,17 @@ CFCMethod_finalize(CFCMethod *self) {
     return finalized;
 }
 
+int
+CFCMethod_can_be_bound(CFCMethod *method) {
+    /*
+     * Check for
+     * - private methods
+     * - methods with types which cannot be mapped automatically
+     */
+    return !CFCSymbol_private((CFCSymbol*)method)
+           && CFCFunction_can_be_bound((CFCFunction*)method);
+}
+
 void
 CFCMethod_set_host_alias(CFCMethod *self, const char *alias) {
     if (!alias || !alias[0]) {

--- a/compiler/src/CFCMethod.h
+++ b/compiler/src/CFCMethod.h
@@ -107,6 +107,11 @@ CFCMethod_override(CFCMethod *self, CFCMethod *orig);
 CFCMethod*
 CFCMethod_finalize(CFCMethod *self);
 
+/** Test whether bindings should be generated for a method.
+  */
+int
+CFCMethod_can_be_bound(CFCMethod *method);
+
 /**
  * Find the first declaration of the method in the class hierarchy.
  */

--- a/compiler/src/CFCPerlClass.c
+++ b/compiler/src/CFCPerlClass.c
@@ -23,6 +23,7 @@
 #include "CFCPerlClass.h"
 #include "CFCUtil.h"
 #include "CFCClass.h"
+#include "CFCFunction.h"
 #include "CFCMethod.h"
 #include "CFCParcel.h"
 #include "CFCParamList.h"
@@ -288,7 +289,7 @@ CFCPerlClass_constructor_bindings(CFCClass *klass) {
         if (perl_class == NULL) {
             // Bind init() to new() when possible.
             if (strcmp(micro_sym, "init") == 0
-                && CFCPerlSub_can_be_bound(function)
+                && CFCFunction_can_be_bound(function)
                ) {
                 alias = NEW;
             }
@@ -297,7 +298,7 @@ CFCPerlClass_constructor_bindings(CFCClass *klass) {
             for (size_t j = 0; j < perl_class->num_cons; j++) {
                 if (strcmp(micro_sym, perl_class->cons_inits[j]) == 0) {
                     alias = perl_class->cons_aliases[j];
-                    if (!CFCPerlSub_can_be_bound(function)) {
+                    if (!CFCFunction_can_be_bound(function)) {
                         CFCUtil_die("Can't bind %s as %s"
                                     " -- types can't be mapped",
                                     micro_sym, alias);
@@ -310,7 +311,7 @@ CFCPerlClass_constructor_bindings(CFCClass *klass) {
             if (!alias
                 && !perl_class->exclude_cons
                 && strcmp(micro_sym, "init") == 0
-                && CFCPerlSub_can_be_bound(function)
+                && CFCFunction_can_be_bound(function)
                ) {
                 int saw_new = 0;
                 for (size_t j = 0; j < perl_class->num_cons; j++) {

--- a/compiler/src/CFCPerlClass.c
+++ b/compiler/src/CFCPerlClass.c
@@ -245,7 +245,7 @@ CFCPerlClass_method_bindings(CFCClass *klass) {
         }
 
         // Skip methods that shouldn't be bound.
-        if (!CFCPerlMethod_can_be_bound(method)) {
+        if (!CFCMethod_can_be_bound(method)) {
             continue;
         }
 

--- a/compiler/src/CFCPerlMethod.c
+++ b/compiler/src/CFCPerlMethod.c
@@ -121,17 +121,6 @@ CFCPerlMethod_destroy(CFCPerlMethod *self) {
     CFCPerlSub_destroy((CFCPerlSub*)self);
 }
 
-int
-CFCPerlMethod_can_be_bound(CFCMethod *method) {
-    /*
-     * Check for
-     * - private methods
-     * - methods with types which cannot be mapped automatically
-     */
-    return !CFCSymbol_private((CFCSymbol*)method)
-           && CFCFunction_can_be_bound((CFCFunction*)method);
-}
-
 char*
 CFCPerlMethod_perl_name(CFCMethod *method) {
     // See if the user wants the method to have a specific alias.
@@ -445,7 +434,7 @@ char*
 CFCPerlMethod_callback_def(CFCMethod *method) {
     // Return a callback wrapper that throws an error if there are no
     // bindings for a method.
-    if (!CFCPerlMethod_can_be_bound(method)) {
+    if (!CFCMethod_can_be_bound(method)) {
         return S_invalid_callback_def(method);
     }
 

--- a/compiler/src/CFCPerlMethod.c
+++ b/compiler/src/CFCPerlMethod.c
@@ -129,7 +129,7 @@ CFCPerlMethod_can_be_bound(CFCMethod *method) {
      * - methods with types which cannot be mapped automatically
      */
     return !CFCSymbol_private((CFCSymbol*)method)
-           && CFCPerlSub_can_be_bound((CFCFunction*)method);
+           && CFCFunction_can_be_bound((CFCFunction*)method);
 }
 
 char*

--- a/compiler/src/CFCPerlMethod.h
+++ b/compiler/src/CFCPerlMethod.h
@@ -46,11 +46,6 @@ CFCPerlMethod_init(CFCPerlMethod *self, struct CFCMethod *method);
 void
 CFCPerlMethod_destroy(CFCPerlMethod *self);
 
-/** Test whether bindings should be generated for a method.
-  */
-int
-CFCPerlMethod_can_be_bound(struct CFCMethod *method);
-
 /**
  * Create the Perl name of the method.
  */

--- a/compiler/src/CFCPerlSub.c
+++ b/compiler/src/CFCPerlSub.c
@@ -73,30 +73,6 @@ CFCPerlSub_destroy(CFCPerlSub *self) {
     CFCBase_destroy((CFCBase*)self);
 }
 
-int
-CFCPerlSub_can_be_bound(CFCFunction *function) {
-    // Test whether parameters can be mapped automatically.
-    CFCParamList  *param_list = CFCFunction_get_param_list(function);
-    CFCVariable  **arg_vars   = CFCParamList_get_variables(param_list);
-    for (size_t i = 0; arg_vars[i] != NULL; i++) {
-        CFCType *type = CFCVariable_get_type(arg_vars[i]);
-        if (!CFCType_is_object(type) && !CFCType_is_primitive(type)) {
-            return false;
-        }
-    }
-
-    // Test whether return type can be mapped automatically.
-    CFCType *return_type = CFCFunction_get_return_type(function);
-    if (!CFCType_is_void(return_type)
-        && !CFCType_is_object(return_type)
-        && !CFCType_is_primitive(return_type)
-    ) {
-        return false;
-    }
-
-    return true;
-}
-
 char*
 CFCPerlSub_params_hash_def(CFCPerlSub *self) {
     if (!self->use_labeled_params) {

--- a/compiler/src/CFCPerlSub.h
+++ b/compiler/src/CFCPerlSub.h
@@ -65,11 +65,6 @@ CFCPerlSub_init(CFCPerlSub *self, struct CFCParamList *param_list,
 void
 CFCPerlSub_destroy(CFCPerlSub *self);
 
-/** Test whether bindings can be generated for a function.
-  */
-int
-CFCPerlSub_can_be_bound(struct CFCFunction *function);
-
 /** Return Perl code initializing a package-global hash where all the keys are
  * the names of labeled params.  The hash's name consists of the the binding's
  * perl_name() plus "_PARAMS".


### PR DESCRIPTION
Consolidate tests for whether Clownfish functions and methods can be bound to a host.