### PR TITLE
CLOWNFISH-32 capture "abstract" keyword

### DIFF
--- a/compiler/perl/lib/Clownfish/CFC.pm
+++ b/compiler/perl/lib/Clownfish/CFC.pm
@@ -123,6 +123,7 @@ BEGIN { XSLoader::load( 'Clownfish::CFC', '0.4.0' ) }
         inert             => undef,
         final             => undef,
         parcel            => undef,
+        abstract          => undef,
         exposure          => 'parcel',
     );
 
@@ -156,7 +157,7 @@ BEGIN { XSLoader::load( 'Clownfish::CFC', '0.4.0' ) }
         return _create(
             @args{
                 qw( parcel exposure class_name nickname micro_sym docucomment
-                    file_spec parent_class_name final inert)
+                    file_spec parent_class_name final inert abstract )
                 }
         );
     }

--- a/compiler/perl/lib/Clownfish/CFC.xs
+++ b/compiler/perl/lib/Clownfish/CFC.xs
@@ -155,7 +155,7 @@ PPCODE:
 MODULE = Clownfish::CFC   PACKAGE = Clownfish::CFC::Model::Class
 
 SV*
-_create(parcel, exposure_sv, class_name_sv, class_nickname_sv, micro_sym_sv, docucomment, file_spec, parent_class_name_sv, is_final, is_inert)
+_create(parcel, exposure_sv, class_name_sv, class_nickname_sv, micro_sym_sv, docucomment, file_spec, parent_class_name_sv, is_final, is_inert, is_abstract)
     CFCParcel *parcel;
     SV *exposure_sv;
     SV *class_name_sv;
@@ -166,6 +166,7 @@ _create(parcel, exposure_sv, class_name_sv, class_nickname_sv, micro_sym_sv, doc
     SV *parent_class_name_sv;
     bool is_final;
     bool is_inert;
+    bool is_abstract;
 CODE:
     const char *exposure =
         SvOK(exposure_sv) ? SvPV_nolen(exposure_sv) : NULL;
@@ -180,7 +181,7 @@ CODE:
     CFCClass *self
         = CFCClass_create(parcel, exposure, class_name, class_nickname,
                           micro_sym, docucomment, file_spec, parent_class_name,
-                          is_final, is_inert);
+                          is_final, is_inert, is_abstract);
     RETVAL = S_cfcbase_to_perlref(self);
     CFCBase_decref((CFCBase*)self);
 OUTPUT: RETVAL

--- a/compiler/src/CFCClass.c
+++ b/compiler/src/CFCClass.c
@@ -70,6 +70,7 @@ struct CFCClass {
     char *parent_class_name;
     int is_final;
     int is_inert;
+    int is_abstract;
     char *struct_sym;
     char *full_struct_sym;
     char *ivars_struct;
@@ -106,11 +107,12 @@ CFCClass_create(struct CFCParcel *parcel, const char *exposure,
                 const char *class_name, const char *nickname,
                 const char *micro_sym, CFCDocuComment *docucomment,
                 CFCFileSpec *file_spec, const char *parent_class_name,
-                int is_final, int is_inert) {
+                int is_final, int is_inert, int is_abstract) {
     CFCClass *self = (CFCClass*)CFCBase_allocate(&CFCCLASS_META);
     return CFCClass_do_create(self, parcel, exposure, class_name, nickname,
                               micro_sym, docucomment, file_spec,
-                              parent_class_name, is_final, is_inert);
+                              parent_class_name, is_final, is_inert,
+                              is_abstract);
 }
 
 CFCClass*
@@ -118,7 +120,8 @@ CFCClass_do_create(CFCClass *self, struct CFCParcel *parcel,
                    const char *exposure, const char *class_name,
                    const char *nickname, const char *micro_sym,
                    CFCDocuComment *docucomment, CFCFileSpec *file_spec,
-                   const char *parent_class_name, int is_final, int is_inert) {
+                   const char *parent_class_name, int is_final, int is_inert,
+                   int is_abstract) {
     CFCUTIL_NULL_CHECK(class_name);
     exposure  = exposure  ? exposure  : "parcel";
     micro_sym = micro_sym ? micro_sym : "class";
@@ -191,6 +194,7 @@ CFCClass_do_create(CFCClass *self, struct CFCParcel *parcel,
 
     self->is_final    = !!is_final;
     self->is_inert    = !!is_inert;
+    self->is_abstract = !!is_abstract;
 
     if (!CFCClass_included(self) && CFCParcel_included(parcel)) {
         CFCUtil_die("Class %s from source dir found in parcel %s from"
@@ -766,6 +770,11 @@ CFCClass_final(CFCClass *self) {
 int
 CFCClass_inert(CFCClass *self) {
     return self->is_inert;
+}
+
+int
+CFCClass_abstract(CFCClass *self) {
+    return self->is_abstract;
 }
 
 const char*

--- a/compiler/src/CFCClass.h
+++ b/compiler/src/CFCClass.h
@@ -55,13 +55,14 @@ struct CFCFileSpec;
  * @param is_inert Should be true if the class is inert, i.e. cannot be
  * instantiated.
  * @param is_final Should be true if the class is final.
+ * @param is_abstract Should be true if the class is abstract.
  */
 CFCClass*
 CFCClass_create(struct CFCParcel *parcel, const char *exposure,
                 const char *class_name, const char *nickname,
                 const char *micro_sym, struct CFCDocuComment *docucomment,
                 struct CFCFileSpec *file_spec, const char *parent_class_name,
-                int is_final, int is_inert);
+                int is_final, int is_inert, int is_abstract);
 
 CFCClass*
 CFCClass_do_create(CFCClass *self, struct CFCParcel *parcel,
@@ -69,7 +70,7 @@ CFCClass_do_create(CFCClass *self, struct CFCParcel *parcel,
                    const char *nickname, const char *micro_sym,
                    struct CFCDocuComment *docucomment,
                    struct CFCFileSpec *file_spec, const char *parent_class_name,
-                   int is_final, int is_inert);
+                   int is_final, int is_inert, int is_abstract);
 
 void
 CFCClass_destroy(CFCClass *self);
@@ -228,6 +229,9 @@ CFCClass_final(CFCClass *self);
 
 int
 CFCClass_inert(CFCClass *self);
+
+int
+CFCClass_abstract(CFCClass *self);
 
 const char*
 CFCClass_get_struct_sym(CFCClass *self);

--- a/compiler/src/CFCParseHeader.y
+++ b/compiler/src/CFCParseHeader.y
@@ -40,20 +40,21 @@ S_start_class(CFCParser *state, CFCDocuComment *docucomment, char *exposure,
     CFCFileSpec *file_spec = CFCParser_get_file_spec(state);
     int is_final = false;
     int is_inert = false;
+    int is_abstract = false;
     if (modifiers) {
-        /* TODO: Decide how to handle abstract classes. */
         if (strstr(modifiers, "inline")) {
             CFCUtil_die("Illegal class modifiers: '%s'", modifiers);
         }
         is_final = !!strstr(modifiers, "final");
         is_inert = !!strstr(modifiers, "inert");
+        is_abstract = !!strstr(modifiers, "abstract");
     }
     CFCParser_set_class_name(state, class_name);
     CFCParser_set_class_nickname(state, class_nickname);
     CFCClass *klass = CFCClass_create(CFCParser_get_parcel(state), exposure,
                                       class_name, class_nickname, NULL,
                                       docucomment, file_spec, inheritance,
-                                      is_final, is_inert);
+                                      is_final, is_inert, is_abstract);
     CFCBase_decref((CFCBase*)docucomment);
     return klass;
 }

--- a/compiler/src/CFCTestClass.c
+++ b/compiler/src/CFCTestClass.c
@@ -87,7 +87,7 @@ S_run_tests(CFCTest *test) {
 
     CFCClass *foo
         = CFCClass_create(neato, NULL, "Foo", NULL, NULL, NULL, NULL, NULL,
-                          0, 0);
+                          0, 0, 0);
     CFCClass_add_function(foo, tread_water);
     CFCClass_add_member_var(foo, thing);
     CFCClass_add_inert_var(foo, widget);
@@ -99,7 +99,7 @@ S_run_tests(CFCTest *test) {
 
     CFCClass *foo_jr
         = CFCClass_create(neato, NULL, "Foo::FooJr", NULL, NULL, NULL, NULL,
-                          "Foo", 0, 0);
+                          "Foo", 0, 0, 0);
     STR_EQ(test, CFCClass_get_struct_sym(foo_jr), "FooJr",
            "get_struct_sym");
     STR_EQ(test, CFCClass_full_struct_sym(foo_jr), "neato_FooJr",
@@ -107,7 +107,7 @@ S_run_tests(CFCTest *test) {
 
     CFCClass *final_foo
         = CFCClass_create(neato, NULL, "Foo::FooJr::FinalFoo", NULL, NULL, NULL,
-                          file_spec, "Foo::FooJr", 1, 0);
+                          file_spec, "Foo::FooJr", 1, 0, 0);
     OK(test, CFCClass_final(final_foo), "final");
     STR_EQ(test, CFCClass_include_h(final_foo), "Foo/FooJr.h",
            "include_h uses path_part");

--- a/compiler/src/CFCTestDocuComment.c
+++ b/compiler/src/CFCTestDocuComment.c
@@ -142,7 +142,7 @@ S_test_generator(CFCTest *test) {
     );
     CFCClass *klass
         = CFCClass_create(parcel, "public", "Neato::Object", NULL, NULL,
-                          docu, NULL, NULL, 0, 0);
+                          docu, NULL, NULL, 0, 0, 0);
 
     char *man_page = CFCCMan_create_man_page(klass);
     const char *expected_man =

--- a/compiler/src/CFCTestType.c
+++ b/compiler/src/CFCTestType.c
@@ -331,7 +331,7 @@ S_run_object_tests(CFCTest *test) {
     CFCParcel *neato_parcel = CFCParcel_new("Neato", NULL, NULL, NULL);
     CFCClass *foo_class
         = CFCClass_create(neato_parcel, NULL, "Foo", NULL, NULL, NULL, NULL,
-                          NULL, false, false);
+                          NULL, false, false, false);
     CFCType *foo = CFCType_new_object(0, neato_parcel, "Foo", 1);
     CFCType_resolve(foo);
 
@@ -345,7 +345,7 @@ S_run_object_tests(CFCTest *test) {
     {
         CFCClass *bar_class
             = CFCClass_create(neato_parcel, NULL, "Bar", NULL, NULL, NULL,
-                              NULL, NULL, false, false);
+                              NULL, NULL, false, false, false);
         CFCType *bar = CFCType_new_object(0, neato_parcel, "Bar", 1);
         CFCType_resolve(bar);
         OK(test, !CFCType_equals(foo, bar),
@@ -359,7 +359,7 @@ S_run_object_tests(CFCTest *test) {
             = CFCParcel_new("Foreign", NULL, NULL, NULL);
         CFCClass *foreign_foo_class
             = CFCClass_create(foreign_parcel, NULL, "Foreign::Foo", NULL, NULL,
-                              NULL, NULL, NULL, false, false);
+                              NULL, NULL, NULL, false, false, false);
         CFCType *foreign_foo = CFCType_new_object(0, foreign_parcel, "Foo", 1);
         CFCType_resolve(foreign_foo);
         OK(test, !CFCType_equals(foo, foreign_foo),

--- a/runtime/core/Clownfish/Obj.cfh
+++ b/runtime/core/Clownfish/Obj.cfh
@@ -19,7 +19,7 @@ parcel Clownfish;
 /** Base class for all objects.
  */
 
-public class Clownfish::Obj {
+public abstract class Clownfish::Obj {
 
     Class *klass;
 


### PR DESCRIPTION
The keyword "abstract" is only advisory when applied to classes.  It would be nice if the compiler at least captured it, even if it doesn't yet do anything with it.

See CLOWNFISH-32.