### PR TITLE
CLOWNFISH-9 Mark most types final

### DIFF
--- a/compiler/perl/lib/Clownfish/CFC.xs
+++ b/compiler/perl/lib/Clownfish/CFC.xs
@@ -2138,10 +2138,11 @@ CODE:
 OUTPUT: RETVAL
 
 SV*
-build_allot_params(self)
+build_allot_params(self, first)
     CFCPerlSub *self;
+    size_t first;
 CODE:
-    RETVAL = S_sv_eat_c_string(CFCPerlSub_build_allot_params(self));
+    RETVAL = S_sv_eat_c_string(CFCPerlSub_build_allot_params(self, first));
 OUTPUT: RETVAL
 
 

--- a/compiler/src/CFCBindClass.c
+++ b/compiler/src/CFCBindClass.c
@@ -617,10 +617,8 @@ S_sub_declarations(CFCBindClass *self) {
     for (int i = 0; fresh_methods[i] != NULL; i++) {
         CFCMethod *method = fresh_methods[i];
         char *dec = CFCBindMeth_imp_declaration(method);
-        if (CFCMethod_final(method)) {
-            declarations = CFCUtil_cat(declarations, PREFIX, "VISIBLE ", NULL);
-        }
-        declarations = CFCUtil_cat(declarations, dec, "\n\n", NULL);
+        declarations = CFCUtil_cat(declarations, PREFIX, "VISIBLE ", dec,
+                                   "\n\n", NULL);
         FREEMEM(dec);
     }
     return declarations;

--- a/compiler/src/CFCBindMethod.c
+++ b/compiler/src/CFCBindMethod.c
@@ -48,6 +48,7 @@ CFCBindMeth_method_def(CFCMethod *method, CFCClass *klass) {
  * this method may not be overridden. */
 static char*
 S_final_method_def(CFCMethod *method, CFCClass *klass) {
+    const char *PREFIX = CFCClass_get_PREFIX(klass);
     const char *self_type = CFCType_to_c(CFCMethod_self_type(method));
     const char *full_func_sym = CFCMethod_imp_func(method);
     const char *arg_names 
@@ -57,12 +58,12 @@ S_final_method_def(CFCMethod *method, CFCClass *klass) {
     char *full_offset_sym = CFCMethod_full_offset_sym(method, klass);
 
     const char pattern[] =
-        "extern size_t %s;\n"
+        "extern %sVISIBLE size_t %s;\n"
         "#define %s(%s) \\\n"
         "    %s((%s)%s)\n";
     char *method_def
-        = CFCUtil_sprintf(pattern, full_offset_sym, full_meth_sym, arg_names,
-                          full_func_sym, self_type, arg_names);
+        = CFCUtil_sprintf(pattern, PREFIX, full_offset_sym, full_meth_sym,
+                          arg_names, full_func_sym, self_type, arg_names);
 
     FREEMEM(full_offset_sym);
     FREEMEM(full_meth_sym);

--- a/compiler/src/CFCPerlClass.c
+++ b/compiler/src/CFCPerlClass.c
@@ -268,8 +268,6 @@ CFCPerlClass_method_bindings(CFCClass *klass) {
     return bound;
 }
 
-static const char NEW[] = "new";
-
 CFCPerlConstructor**
 CFCPerlClass_constructor_bindings(CFCClass *klass) {
     const char    *class_name = CFCClass_get_class_name(klass);
@@ -278,6 +276,8 @@ CFCPerlClass_constructor_bindings(CFCClass *klass) {
     size_t         num_bound  = 0;
     CFCPerlConstructor **bound 
         = (CFCPerlConstructor**)CALLOCATE(1, sizeof(CFCPerlConstructor*));
+    const char *default_func = CFCClass_final(klass)
+                               ? "new" : "init";
 
     // Iterate over the list of possible initialization functions.
     for (size_t i = 0; functions[i] != NULL; i++) {
@@ -288,10 +288,10 @@ CFCPerlClass_constructor_bindings(CFCClass *klass) {
         // Find user-specified alias.
         if (perl_class == NULL) {
             // Bind init() to new() when possible.
-            if (strcmp(func_name, "init") == 0
+            if (strcmp(func_name, default_func) == 0
                 && CFCFunction_can_be_bound(function)
                ) {
-                alias = NEW;
+                alias = "new";
             }
         }
         else {
@@ -310,7 +310,7 @@ CFCPerlClass_constructor_bindings(CFCClass *klass) {
             // Automatically bind init() to new() when possible.
             if (!alias
                 && !perl_class->exclude_cons
-                && strcmp(func_name, "init") == 0
+                && strcmp(func_name, default_func) == 0
                 && CFCFunction_can_be_bound(function)
                ) {
                 int saw_new = 0;
@@ -320,7 +320,7 @@ CFCPerlClass_constructor_bindings(CFCClass *klass) {
                     }
                 }
                 if (!saw_new) {
-                    alias = NEW;
+                    alias = "new";
                 }
             }
         }

--- a/compiler/src/CFCPerlConstructor.c
+++ b/compiler/src/CFCPerlConstructor.c
@@ -94,8 +94,8 @@ CFCPerlConstructor_xsub_def(CFCPerlConstructor *self) {
     char         *name_list  = CFCPerlSub_arg_name_list((CFCPerlSub*)self);
     CFCVariable **arg_vars   = CFCParamList_get_variables(param_list);
     const char   *func_sym   = CFCFunction_full_func_sym(self->init_func);
-    char *arg_decls    = CFCPerlSub_arg_declarations((CFCPerlSub*)self);
-    char *allot_params = CFCPerlSub_build_allot_params((CFCPerlSub*)self);
+    char *arg_decls    = CFCPerlSub_arg_declarations((CFCPerlSub*)self, 1);
+    char *allot_params = CFCPerlSub_build_allot_params((CFCPerlSub*)self, 1);
     CFCVariable *self_var       = arg_vars[0];
     CFCType     *self_type      = CFCVariable_get_type(self_var);
     const char  *self_type_str  = CFCType_to_c(self_type);

--- a/compiler/src/CFCPerlConstructor.h
+++ b/compiler/src/CFCPerlConstructor.h
@@ -37,7 +37,7 @@ struct CFCClass;
  * @param klass A L<Clownfish::CFC::Model::Class>.
  * @param alias The Perl name for the constructor.
  * @param initializer The name of the function which should be bound (default
- * "init").
+ * "init" for an extensible class, and "new" for a final class).
  */
 CFCPerlConstructor*
 CFCPerlConstructor_new(struct CFCClass *klass, const char *alias,

--- a/compiler/src/CFCPerlMethod.c
+++ b/compiler/src/CFCPerlMethod.c
@@ -240,10 +240,10 @@ S_xsub_def_labeled_params(CFCPerlMethod *self) {
     CFCType     *return_type = CFCMethod_get_return_type(method);
     const char  *self_type_c = CFCType_to_c(self_type);
     const char  *self_name   = CFCVariable_get_name(self_var);
-    char *arg_decls    = CFCPerlSub_arg_declarations((CFCPerlSub*)self);
+    char *arg_decls    = CFCPerlSub_arg_declarations((CFCPerlSub*)self, 1);
     char *meth_type_c  = CFCMethod_full_typedef(method, NULL);
     char *self_assign  = S_self_assign_statement(self, self_type);
-    char *allot_params = CFCPerlSub_build_allot_params((CFCPerlSub*)self);
+    char *allot_params = CFCPerlSub_build_allot_params((CFCPerlSub*)self, 1);
     char *body         = S_xsub_body(self);
 
     char *retval_decl;
@@ -301,7 +301,7 @@ S_xsub_def_positional_args(CFCPerlMethod *self) {
     const char  *self_type_c = CFCType_to_c(self_type);
     const char **arg_inits = CFCParamList_get_initial_values(param_list);
     unsigned num_vars = (unsigned)CFCParamList_num_vars(param_list);
-    char *arg_decls   = CFCPerlSub_arg_declarations((CFCPerlSub*)self);
+    char *arg_decls   = CFCPerlSub_arg_declarations((CFCPerlSub*)self, 1);
     char *meth_type_c = CFCMethod_full_typedef(method, NULL);
     char *self_assign = S_self_assign_statement(self, self_type);
     char *body        = S_xsub_body(self);

--- a/compiler/src/CFCPerlSub.c
+++ b/compiler/src/CFCPerlSub.c
@@ -179,14 +179,14 @@ S_allot_params_arg(CFCType *type, const char *label, int required) {
 }
 
 char*
-CFCPerlSub_arg_declarations(CFCPerlSub *self) {
+CFCPerlSub_arg_declarations(CFCPerlSub *self, size_t first) {
     CFCParamList *param_list = self->param_list;
     CFCVariable **arg_vars   = CFCParamList_get_variables(param_list);
     size_t        num_vars   = CFCParamList_num_vars(param_list);
     char         *decls      = CFCUtil_strdup("");
 
     // Declare variables.
-    for (size_t i = 1; i < num_vars; i++) {
+    for (size_t i = first; i < num_vars; i++) {
         CFCVariable *arg_var  = arg_vars[i];
         CFCType     *type     = CFCVariable_get_type(arg_var);
         const char  *type_str = CFCType_to_c(type);
@@ -203,18 +203,21 @@ CFCPerlSub_arg_name_list(CFCPerlSub *self) {
     CFCParamList  *param_list = self->param_list;
     CFCVariable  **arg_vars   = CFCParamList_get_variables(param_list);
     size_t         num_vars   = CFCParamList_num_vars(param_list);
-    char          *name_list  = CFCUtil_strdup("arg_self");
+    char          *name_list  = CFCUtil_strdup("");
 
-    for (size_t i = 1; i < num_vars; i++) {
+    for (size_t i = 0; i < num_vars; i++) {
         const char *var_name = CFCVariable_get_name(arg_vars[i]);
-        name_list = CFCUtil_cat(name_list, ", arg_", var_name, NULL);
+        if (i > 0) {
+            name_list = CFCUtil_cat(name_list, ", ", NULL);
+        }
+        name_list = CFCUtil_cat(name_list, "arg_", var_name, NULL);
     }
 
     return name_list;
 }
 
 char*
-CFCPerlSub_build_allot_params(CFCPerlSub *self) {
+CFCPerlSub_build_allot_params(CFCPerlSub *self, size_t first) {
     CFCParamList *param_list = self->param_list;
     CFCVariable **arg_vars   = CFCParamList_get_variables(param_list);
     const char  **arg_inits  = CFCParamList_get_initial_values(param_list);
@@ -222,7 +225,7 @@ CFCPerlSub_build_allot_params(CFCPerlSub *self) {
     char *allot_params = CFCUtil_strdup("");
 
     // Declare variables and assign default values.
-    for (size_t i = 1; i < num_vars; i++) {
+    for (size_t i = first; i < num_vars; i++) {
         CFCVariable *arg_var  = arg_vars[i];
         const char  *val      = arg_inits[i];
         const char  *var_name = CFCVariable_get_name(arg_var);
@@ -241,7 +244,7 @@ CFCPerlSub_build_allot_params(CFCPerlSub *self) {
         = CFCUtil_cat(allot_params,
                       "args_ok = XSBind_allot_params(aTHX_\n"
                       "        &(ST(0)), 1, items,\n", NULL);
-    for (size_t i = 1; i < num_vars; i++) {
+    for (size_t i = first; i < num_vars; i++) {
         CFCVariable *var = arg_vars[i];
         const char  *val = arg_inits[i];
         int required = val ? 0 : 1;

--- a/compiler/src/CFCPerlSub.h
+++ b/compiler/src/CFCPerlSub.h
@@ -72,10 +72,11 @@ CFCPerlSub_destroy(CFCPerlSub *self);
 char*
 CFCPerlSub_params_hash_def(CFCPerlSub *self);
 
-/** Generate C declarations for the variables holding the arguments.
+/** Generate C declarations for the variables holding the arguments, from
+ * `first` onwards.
  */
 char*
-CFCPerlSub_arg_declarations(CFCPerlSub *self);
+CFCPerlSub_arg_declarations(CFCPerlSub *self, size_t first);
 
 /** Create a comma-separated list of argument names prefixed by "arg_".
  */
@@ -83,10 +84,11 @@ char*
 CFCPerlSub_arg_name_list(CFCPerlSub *self);
 
 /** Generate code which will invoke XSBind_allot_params() to parse labeled
- * parameters supplied to an XSUB.
+ * parameters supplied to an XSUB.  Parameters from `first` onwards are
+ * included.
  */
 char*
-CFCPerlSub_build_allot_params(CFCPerlSub *self);
+CFCPerlSub_build_allot_params(CFCPerlSub *self, size_t first);
 
 /** Accessor for param list.
  */

--- a/runtime/core/Clownfish/Blob.cfh
+++ b/runtime/core/Clownfish/Blob.cfh
@@ -20,7 +20,7 @@ parcel Clownfish;
  * Immutable buffer holding arbitrary bytes.
  */
 
-class Clownfish::Blob inherits Clownfish::Obj {
+final class Clownfish::Blob inherits Clownfish::Obj {
 
     const char *buf;
     size_t      size;

--- a/runtime/core/Clownfish/ByteBuf.cfh
+++ b/runtime/core/Clownfish/ByteBuf.cfh
@@ -20,7 +20,7 @@ parcel Clownfish;
  * Growable buffer holding arbitrary bytes.
  */
 
-class Clownfish::ByteBuf nickname BB inherits Clownfish::Obj {
+final class Clownfish::ByteBuf nickname BB inherits Clownfish::Obj {
 
     char    *buf;
     size_t   size;  /* number of valid bytes */

--- a/runtime/core/Clownfish/CharBuf.cfh
+++ b/runtime/core/Clownfish/CharBuf.cfh
@@ -20,7 +20,7 @@ parcel Clownfish;
  * Growable buffer holding Unicode characters.
  */
 
-class Clownfish::CharBuf nickname CB
+final class Clownfish::CharBuf nickname CB
     inherits Clownfish::Obj {
 
     char    *ptr;

--- a/runtime/core/Clownfish/Class.cfh
+++ b/runtime/core/Clownfish/Class.cfh
@@ -23,7 +23,7 @@ parcel Clownfish;
  * behavior of Classes.)
  */
 
-class Clownfish::Class inherits Clownfish::Obj {
+final class Clownfish::Class inherits Clownfish::Obj {
 
     Class              *parent;
     String             *name;

--- a/runtime/core/Clownfish/Hash.cfh
+++ b/runtime/core/Clownfish/Hash.cfh
@@ -21,7 +21,7 @@ parcel Clownfish;
  *
  * Values are stored by reference and may be any kind of Obj.
  */
-public class Clownfish::Hash inherits Clownfish::Obj {
+public final class Clownfish::Hash inherits Clownfish::Obj {
 
     void   *entries;
     size_t  capacity;

--- a/runtime/core/Clownfish/HashIterator.cfh
+++ b/runtime/core/Clownfish/HashIterator.cfh
@@ -20,7 +20,7 @@ parcel Clownfish;
  * Hashtable Iterator.
  */
 
-class Clownfish::HashIterator nickname HashIter inherits Clownfish::Obj {
+final class Clownfish::HashIterator nickname HashIter inherits Clownfish::Obj {
     Hash   *hash;
     size_t  tick;
     size_t  capacity;

--- a/runtime/core/Clownfish/Method.cfh
+++ b/runtime/core/Clownfish/Method.cfh
@@ -19,7 +19,7 @@ parcel Clownfish;
 /** Method metadata.
  */
 
-class Clownfish::Method inherits Clownfish::Obj {
+final class Clownfish::Method inherits Clownfish::Obj {
 
     String         *name;
     String         *name_internal;

--- a/runtime/core/Clownfish/Num.cfh
+++ b/runtime/core/Clownfish/Num.cfh
@@ -58,7 +58,7 @@ abstract class Clownfish::IntNum inherits Clownfish::Num {
 
 /** Single precision floating point number.
  */
-class Clownfish::Float32 inherits Clownfish::FloatNum {
+final class Clownfish::Float32 inherits Clownfish::FloatNum {
 
     float value;
 
@@ -92,7 +92,7 @@ class Clownfish::Float32 inherits Clownfish::FloatNum {
 
 /** Double precision floating point number.
  */
-class Clownfish::Float64 inherits Clownfish::FloatNum {
+final class Clownfish::Float64 inherits Clownfish::FloatNum {
 
     double value;
 
@@ -126,7 +126,7 @@ class Clownfish::Float64 inherits Clownfish::FloatNum {
 
 /** 32-bit signed integer.
  */
-class Clownfish::Integer32 nickname Int32
+final class Clownfish::Integer32 nickname Int32
     inherits Clownfish::IntNum {
 
     int32_t value;
@@ -162,7 +162,7 @@ class Clownfish::Integer32 nickname Int32
 /**
  * 64-bit signed integer.
  */
-class Clownfish::Integer64 nickname Int64
+final class Clownfish::Integer64 nickname Int64
     inherits Clownfish::IntNum {
 
     int64_t value;

--- a/runtime/core/Clownfish/Vector.cfh
+++ b/runtime/core/Clownfish/Vector.cfh
@@ -18,7 +18,7 @@ parcel Clownfish;
 
 /** Variable-sized array.
  */
-public class Clownfish::Vector nickname Vec inherits Clownfish::Obj {
+public final class Clownfish::Vector nickname Vec inherits Clownfish::Obj {
 
     Obj      **elems;
     size_t     size;

--- a/runtime/perl/buildlib/Clownfish/Build/Binding.pm
+++ b/runtime/perl/buildlib/Clownfish/Build/Binding.pm
@@ -146,17 +146,16 @@ sub bind_blob {
 MODULE = Clownfish     PACKAGE = Clownfish::Blob
 
 SV*
-new(either_sv, sv)
-    SV *either_sv;
+new(unused_sv, sv)
+    SV *unused_sv;
     SV *sv;
 CODE:
 {
     STRLEN size;
     char *ptr = SvPV(sv, size);
-    cfish_Blob *self
-        = (cfish_Blob*)XSBind_new_blank_obj(aTHX_ either_sv);
-    cfish_Blob_init(self, ptr, size);
+    cfish_Blob *self = cfish_Blob_new(ptr, size);
     RETVAL = CFISH_OBJ_TO_SV_NOINC(self);
+    CFISH_UNUSED_VAR(unused_sv);
 }
 OUTPUT: RETVAL
 END_XS_CODE
@@ -176,18 +175,16 @@ sub bind_bytebuf {
 MODULE = Clownfish     PACKAGE = Clownfish::ByteBuf
 
 SV*
-new(either_sv, sv)
-    SV *either_sv;
+new(unused_sv, sv)
+    SV *unused_sv;
     SV *sv;
 CODE:
 {
     STRLEN size;
     char *ptr = SvPV(sv, size);
-    cfish_ByteBuf *self
-        = (cfish_ByteBuf*)XSBind_new_blank_obj(aTHX_ either_sv);
-    cfish_BB_init(self, size);
-    CFISH_BB_Mimic_Bytes(self, ptr, size);
+    cfish_ByteBuf *self = cfish_BB_new_bytes(ptr, size);
     RETVAL = CFISH_OBJ_TO_SV_NOINC(self);
+    CFISH_UNUSED_VAR(unused_sv);
 }
 OUTPUT: RETVAL
 END_XS_CODE
@@ -336,15 +333,14 @@ sub bind_float32 {
 MODULE = Clownfish   PACKAGE = Clownfish::Float32
 
 SV*
-new(either_sv, value)
-    SV    *either_sv;
+new(unused_sv, value)
+    SV    *unused_sv;
     float  value;
 CODE:
 {
-    cfish_Float32 *self
-        = (cfish_Float32*)XSBind_new_blank_obj(aTHX_ either_sv);
-    cfish_Float32_init(self, value);
+    cfish_Float32 *self = cfish_Float32_new(value);
     RETVAL = CFISH_OBJ_TO_SV_NOINC(self);
+    CFISH_UNUSED_VAR(unused_sv);
 }
 OUTPUT: RETVAL
 END_XS_CODE
@@ -364,15 +360,14 @@ sub bind_float64 {
 MODULE = Clownfish   PACKAGE = Clownfish::Float64
 
 SV*
-new(either_sv, value)
-    SV     *either_sv;
+new(unused_sv, value)
+    SV     *unused_sv;
     double  value;
 CODE:
 {
-    cfish_Float64 *self
-        = (cfish_Float64*)XSBind_new_blank_obj(aTHX_ either_sv);
-    cfish_Float64_init(self, value);
+    cfish_Float64 *self = cfish_Float64_new(value);
     RETVAL = CFISH_OBJ_TO_SV_NOINC(self);
+    CFISH_UNUSED_VAR(unused_sv);
 }
 OUTPUT: RETVAL
 END_XS_CODE

--- a/runtime/perl/t/021-class.t
+++ b/runtime/perl/t/021-class.t
@@ -16,8 +16,8 @@
 use strict;
 use warnings;
 
-package MyHash;
-use base qw( Clownfish::Hash );
+package MyObj;
+use base qw( Clownfish::Obj );
 
 sub oodle { }
 
@@ -29,29 +29,26 @@ my $stringified;
 my $storage = Clownfish::Hash->new;
 
 {
-    my $subclassed_hash = MyHash->new;
-    $stringified = $subclassed_hash->to_string;
+    my $subclassed_obj = MyObj->new;
+    $stringified = $subclassed_obj->to_string;
 
-    isa_ok( $subclassed_hash, "MyHash", "Perl isa reports correct subclass" );
+    isa_ok( $subclassed_obj, "MyObj", "Perl isa reports correct subclass" );
 
    # Store the subclassed object.  At the end of this block, the Perl object
    # will go out of scope and DESTROY will be called, but the Clownfish object
    # will persist.
-    $storage->store( "test", $subclassed_hash );
+    $storage->store( "test", $subclassed_obj );
 }
 
 my $resurrected = $storage->_fetch("test");
 
-isa_ok( $resurrected, "MyHash", "subclass name survived Perl destruction" );
+isa_ok( $resurrected, "MyObj", "subclass name survived Perl destruction" );
 is( $resurrected->to_string, $stringified,
     "It's the same Hash from earlier (though a different Perl object)" );
 
-my $booga = Clownfish::String->new("booga");
-$resurrected->store( "ooga", $booga );
+is( $resurrected->get_class_name,
+    "MyObj", "subclassed object still performs correctly at the C level" );
 
-is( $resurrected->fetch("ooga"),
-    "booga", "subclassed object still performs correctly at the C level" );
-
-my $methods = Clownfish::Class::_fresh_host_methods('MyHash');
+my $methods = Clownfish::Class::_fresh_host_methods('MyObj');
 is_deeply( $methods->to_perl, ['oodle'], "fresh_host_methods" );
 


### PR DESCRIPTION
Mark most core types as `final`: Blob, ByteBuf, CharBuf, Class, Method, Hash, HashIterator, Vector, and the concrete Num types.

Conspicuous omissions include Obj and Err which need to be extensible, and String and StringIterator, which need to be refactored to accommodate stack allocations without subclassing. 

Commit 9a71917, "Export all _IMP symbols" is a bit like swatting a fly with a sledgehammer, but without it, Lucy fails dynamic linking because `CFISH_Num_Equals_IMP` is not exported. I think that over time as more classes are properly marked as `final` and closed off from extensibility, it will have less impact.