### PR TITLE
CLOWNFISH-50-obj-method-to-inert-v2

### DIFF
--- a/compiler/src/CFCBindClass.c
+++ b/compiler/src/CFCBindClass.c
@@ -669,9 +669,15 @@ S_wrapper_defs(CFCBindClass *self) {
         "static CFISH_INLINE cfish_String*\n"
         "%s%s_get_class_name(%s *self) {\n"
         "    return cfish_Obj_get_class_name((cfish_Obj*)self);\n"
+        "}\n"
+        "\n"
+        "static CFISH_INLINE bool\n"
+        "%s%s_is_a(%s *self, cfish_Class *ancestor) {\n"
+        "    return cfish_Obj_is_a((cfish_Obj*)self, ancestor);\n"
         "}\n";
 
     return CFCUtil_sprintf(pattern,
+                           prefix, nickname, struct_sym,
                            prefix, nickname, struct_sym,
                            prefix, nickname, struct_sym);
 }
@@ -777,7 +783,8 @@ S_short_names(CFCBindClass *self) {
     if (strcmp(CFCClass_get_name(client), "Clownfish::Obj") != 0) {
         static const char *wrapped_funcs[] = {
             "get_class",
-            "get_class_name"
+            "get_class_name",
+            "is_a"
         };
         static int num_wrapped_funcs
             = sizeof(wrapped_funcs) / sizeof(wrapped_funcs[0]);

--- a/compiler/src/CFCBindClass.c
+++ b/compiler/src/CFCBindClass.c
@@ -664,9 +664,16 @@ S_wrapper_defs(CFCBindClass *self) {
         "static CFISH_INLINE cfish_Class*\n"
         "%s%s_get_class(%s *self) {\n"
         "    return cfish_Obj_get_class((cfish_Obj*)self);\n"
+        "}\n"
+        "\n"
+        "static CFISH_INLINE cfish_String*\n"
+        "%s%s_get_class_name(%s *self) {\n"
+        "    return cfish_Obj_get_class_name((cfish_Obj*)self);\n"
         "}\n";
 
-    return CFCUtil_sprintf(pattern, prefix, nickname, struct_sym);
+    return CFCUtil_sprintf(pattern,
+                           prefix, nickname, struct_sym,
+                           prefix, nickname, struct_sym);
 }
 
 // Define method invocation inline functions.
@@ -769,7 +776,8 @@ S_short_names(CFCBindClass *self) {
     // Wrappers.
     if (strcmp(CFCClass_get_name(client), "Clownfish::Obj") != 0) {
         static const char *wrapped_funcs[] = {
-            "get_class"
+            "get_class",
+            "get_class_name"
         };
         static int num_wrapped_funcs
             = sizeof(wrapped_funcs) / sizeof(wrapped_funcs[0]);

--- a/compiler/src/CFCPerl.c
+++ b/compiler/src/CFCPerl.c
@@ -610,7 +610,7 @@ S_write_callbacks_c(CFCPerl *self) {
         "    LEAVE;\n"
         "    if (!nullable && !retval) {\n"
         "        CFISH_THROW(CFISH_ERR, \"%%o#%%s cannot return NULL\",\n"
-        "                    CFISH_Obj_Get_Class_Name((cfish_Obj*)vself),\n"
+        "                    cfish_Obj_get_class_name((cfish_Obj*)vself),\n"
         "                    meth_name);\n"
         "    }\n"
         "    return retval;\n"

--- a/runtime/core/Clownfish/Blob.c
+++ b/runtime/core/Clownfish/Blob.c
@@ -103,7 +103,7 @@ bool
 Blob_Equals_IMP(Blob *self, Obj *other) {
     Blob *const twin = (Blob*)other;
     if (twin == self)           { return true; }
-    if (!Obj_Is_A(other, BLOB)) { return false; }
+    if (!Obj_is_a(other, BLOB)) { return false; }
     return SI_equals_bytes(self, twin->buf, twin->size);
 }
 

--- a/runtime/core/Clownfish/ByteBuf.c
+++ b/runtime/core/Clownfish/ByteBuf.c
@@ -116,7 +116,7 @@ bool
 BB_Equals_IMP(ByteBuf *self, Obj *other) {
     ByteBuf *const twin = (ByteBuf*)other;
     if (twin == self)              { return true; }
-    if (!Obj_Is_A(other, BYTEBUF)) { return false; }
+    if (!Obj_is_a(other, BYTEBUF)) { return false; }
     return SI_equals_bytes(self, twin->buf, twin->size);
 }
 

--- a/runtime/core/Clownfish/CharBuf.c
+++ b/runtime/core/Clownfish/CharBuf.c
@@ -352,7 +352,7 @@ CB_Mimic_IMP(CharBuf *self, Obj *other) {
         size = twin->size;
     }
     else {
-        THROW(ERR, "CharBuf can't mimic %o", Obj_Get_Class_Name(other));
+        THROW(ERR, "CharBuf can't mimic %o", Obj_get_class_name(other));
         return; // unreachable
     }
     SI_mimic_utf8(self, ptr, size);

--- a/runtime/core/Clownfish/CharBuf.c
+++ b/runtime/core/Clownfish/CharBuf.c
@@ -182,7 +182,7 @@ CB_VCatF_IMP(CharBuf *self, const char *pattern, va_list args) {
                         if (!obj) {
                             CB_Cat_Trusted_Utf8(self, "[NULL]", 6);
                         }
-                        else if (Obj_Is_A(obj, STRING)) {
+                        else if (Obj_is_a(obj, STRING)) {
                             CB_Cat(self, (String*)obj);
                         }
                         else {
@@ -341,12 +341,12 @@ void
 CB_Mimic_IMP(CharBuf *self, Obj *other) {
     const char *ptr;
     size_t size;
-    if (Obj_Is_A(other, CHARBUF)) {
+    if (Obj_is_a(other, CHARBUF)) {
         CharBuf *twin = (CharBuf*)other;
         ptr  = twin->ptr;
         size = twin->size;
     }
-    else if (Obj_Is_A(other, STRING)) {
+    else if (Obj_is_a(other, STRING)) {
         String *twin = (String*)other;
         ptr  = twin->ptr;
         size = twin->size;

--- a/runtime/core/Clownfish/Err.c
+++ b/runtime/core/Clownfish/Err.c
@@ -212,7 +212,7 @@ Err_downcast(Obj *obj, Class *klass, const char *file, int line,
              const char *func) {
     if (obj && !SI_obj_is_a(obj, klass)) {
         Err_throw_at(ERR, file, line, func, "Can't downcast from %o to %o",
-                     Obj_Get_Class_Name(obj), Class_Get_Name(klass));
+                     Obj_get_class_name(obj), Class_Get_Name(klass));
     }
     return obj;
 }
@@ -226,14 +226,14 @@ Err_certify(Obj *obj, Class *klass, const char *file, int line,
     }
     else if (!SI_obj_is_a(obj, klass)) {
         Err_throw_at(ERR, file, line, func, "Can't downcast from %o to %o",
-                     Obj_Get_Class_Name(obj), Class_Get_Name(klass));
+                     Obj_get_class_name(obj), Class_Get_Name(klass));
     }
     return obj;
 }
 
 void
 Err_abstract_method_call(Obj *obj, Class *klass, const char *method_name) {
-    String *class_name = obj ? Obj_Get_Class_Name(obj) : Class_Get_Name(klass);
+    String *class_name = obj ? Obj_get_class_name(obj) : Class_Get_Name(klass);
     THROW(ERR, "Abstract method '%s' not defined by %o", method_name,
           class_name);
 }

--- a/runtime/core/Clownfish/Err.cfh
+++ b/runtime/core/Clownfish/Err.cfh
@@ -237,7 +237,7 @@ cfish_Err_abstract_class_check(cfish_Obj *obj, cfish_Class *klass) {
     cfish_Class *const my_class = (cfish_Class*)((cfish_Dummy*)obj)->klass;
     if (my_class == klass) {
         cfish_String *mess = CFISH_MAKE_MESS("%o is an abstract class",
-                                              CFISH_Obj_Get_Class_Name(obj));
+                                              cfish_Obj_get_class_name(obj));
         CFISH_DECREF_NN(obj);
         cfish_Err_throw_mess(CFISH_ERR, mess);
     }

--- a/runtime/core/Clownfish/Hash.c
+++ b/runtime/core/Clownfish/Hash.c
@@ -262,7 +262,7 @@ Hash_Equals_IMP(Hash *self, Obj *other) {
     Hash    *twin = (Hash*)other;
 
     if (twin == self)             { return true; }
-    if (!Obj_Is_A(other, HASH))   { return false; }
+    if (!Obj_is_a(other, HASH))   { return false; }
     if (self->size != twin->size) { return false; }
 
     HashEntry *entry       = (HashEntry*)self->entries;

--- a/runtime/core/Clownfish/Num.c
+++ b/runtime/core/Clownfish/Num.c
@@ -41,7 +41,7 @@ bool
 Num_Equals_IMP(Num *self, Obj *other) {
     Num *twin = (Num*)other;
     if (twin == self) { return true; }
-    if (!Obj_Is_A(other, NUM)) { return false; }
+    if (!Obj_is_a(other, NUM)) { return false; }
     if (Num_To_F64(self) != Num_To_F64(twin)) { return false; }
     if (Num_To_I64(self) != Num_To_I64(twin)) { return false; }
     return true;
@@ -84,7 +84,7 @@ IntNum_init(IntNum *self) {
 
 int32_t
 IntNum_Compare_To_IMP(IntNum *self, Obj *other) {
-    if (!Obj_Is_A(other, INTNUM)) {
+    if (!Obj_is_a(other, INTNUM)) {
         return -Obj_Compare_To(other, (Obj*)self);
     }
     int64_t self_value  = IntNum_To_I64(self);
@@ -283,8 +283,8 @@ bool
 Int64_Equals_IMP(Integer64 *self, Obj *other) {
     Num *twin = (Num*)other;
     if (twin == (Num*)self)         { return true; }
-    if (!Obj_Is_A(other, NUM)) { return false; }
-    if (Num_Is_A(twin, FLOATNUM)) {
+    if (!Obj_is_a(other, NUM)) { return false; }
+    if (Obj_is_a(other, FLOATNUM)) {
         double  floating_val = Num_To_F64(twin);
         int64_t int_val      = (int64_t)floating_val;
         if ((double)int_val != floating_val) { return false; }

--- a/runtime/core/Clownfish/Obj.c
+++ b/runtime/core/Clownfish/Obj.c
@@ -43,7 +43,7 @@ Obj_Destroy_IMP(Obj *self) {
 }
 
 bool
-Obj_Is_A_IMP(Obj *self, Class *ancestor) {
+Obj_is_a(Obj *self, Class *ancestor) {
     Class *klass = self ? self->klass : NULL;
 
     while (klass != NULL) {

--- a/runtime/core/Clownfish/Obj.c
+++ b/runtime/core/Clownfish/Obj.c
@@ -64,13 +64,13 @@ Obj_Equals_IMP(Obj *self, Obj *other) {
 String*
 Obj_To_String_IMP(Obj *self) {
 #if (CHY_SIZEOF_PTR == 4)
-    return Str_newf("%o@0x%x32", Obj_Get_Class_Name(self), self);
+    return Str_newf("%o@0x%x32", Obj_get_class_name(self), self);
 #elif (CHY_SIZEOF_PTR == 8)
     int64_t   iaddress   = CHY_PTR_TO_I64(self);
     uint64_t  address    = (uint64_t)iaddress;
     uint32_t  address_hi = address >> 32;
     uint32_t  address_lo = address & 0xFFFFFFFF;
-    return Str_newf("%o@0x%x32%x32", Obj_Get_Class_Name(self), address_hi,
+    return Str_newf("%o@0x%x32%x32", Obj_get_class_name(self), address_hi,
                     address_lo);
 #else
   #error "Unexpected pointer size."
@@ -83,7 +83,7 @@ Obj_get_class(Obj *self) {
 }
 
 String*
-Obj_Get_Class_Name_IMP(Obj *self) {
+Obj_get_class_name(Obj *self) {
     return Class_Get_Name(self->klass);
 }
 

--- a/runtime/core/Clownfish/Obj.c
+++ b/runtime/core/Clownfish/Obj.c
@@ -78,7 +78,7 @@ Obj_To_String_IMP(Obj *self) {
 }
 
 Class*
-Obj_Get_Class_IMP(Obj *self) {
+Obj_get_class(Obj *self) {
     return self->klass;
 }
 

--- a/runtime/core/Clownfish/Obj.cfh
+++ b/runtime/core/Clownfish/Obj.cfh
@@ -65,8 +65,8 @@ public abstract class Clownfish::Obj {
 
     /** Return the object's Class.
      */
-    public Class*
-    Get_Class(Obj *self);
+    public inert Class*
+    get_class(Obj *self);
 
     /** Return the name of the class that the object belongs to.
      */

--- a/runtime/core/Clownfish/Obj.cfh
+++ b/runtime/core/Clownfish/Obj.cfh
@@ -70,8 +70,8 @@ public abstract class Clownfish::Obj {
 
     /** Return the name of the class that the object belongs to.
      */
-    public String*
-    Get_Class_Name(Obj *self);
+    public inert String*
+    get_class_name(Obj *self);
 
     /** Indicate whether the object is a descendent of `ancestor`.
      */

--- a/runtime/core/Clownfish/Obj.cfh
+++ b/runtime/core/Clownfish/Obj.cfh
@@ -75,8 +75,8 @@ public abstract class Clownfish::Obj {
 
     /** Indicate whether the object is a descendent of `ancestor`.
      */
-    public bool
-    Is_A(Obj *self, Class *ancestor);
+    public inert bool
+    is_a(Obj *self, Class *ancestor);
 
     /** Generic stringification: "ClassName@hex_mem_address".
      */

--- a/runtime/core/Clownfish/String.c
+++ b/runtime/core/Clownfish/String.c
@@ -353,7 +353,7 @@ bool
 Str_Equals_IMP(String *self, Obj *other) {
     String *const twin = (String*)other;
     if (twin == self)              { return true; }
-    if (!Obj_Is_A(other, STRING)) { return false; }
+    if (!Obj_is_a(other, STRING)) { return false; }
     return Str_Equals_Utf8_IMP(self, twin->ptr, twin->size);
 }
 
@@ -602,7 +602,7 @@ bool
 StrIter_Equals_IMP(StringIterator *self, Obj *other) {
     StringIterator *const twin = (StringIterator*)other;
     if (twin == self)                     { return true; }
-    if (!Obj_Is_A(other, STRINGITERATOR)) { return false; }
+    if (!Obj_is_a(other, STRINGITERATOR)) { return false; }
     return self->string == twin->string
            && self->byte_offset == twin->byte_offset;
 }

--- a/runtime/core/Clownfish/Test/TestObj.c
+++ b/runtime/core/Clownfish/Test/TestObj.c
@@ -89,13 +89,13 @@ static void
 test_Is_A(TestBatchRunner *runner) {
     String *string     = Str_new_from_trusted_utf8("", 0);
     Class  *str_class  = Str_get_class(string);
-    String *class_name = Str_Get_Class_Name(string);
+    String *class_name = Str_get_class_name(string);
 
     TEST_TRUE(runner, Str_Is_A(string, STRING), "String Is_A String.");
     TEST_TRUE(runner, Str_Is_A(string, OBJ), "String Is_A Obj.");
     TEST_TRUE(runner, str_class == STRING, "get_class");
     TEST_TRUE(runner, Str_Equals(Class_Get_Name(STRING), (Obj*)class_name),
-              "Get_Class_Name");
+              "get_class_name");
 
     DECREF(string);
 }

--- a/runtime/core/Clownfish/Test/TestObj.c
+++ b/runtime/core/Clownfish/Test/TestObj.c
@@ -88,12 +88,12 @@ test_Equals(TestBatchRunner *runner) {
 static void
 test_Is_A(TestBatchRunner *runner) {
     String *string     = Str_new_from_trusted_utf8("", 0);
-    Class  *str_class  = Str_Get_Class(string);
+    Class  *str_class  = Str_get_class(string);
     String *class_name = Str_Get_Class_Name(string);
 
     TEST_TRUE(runner, Str_Is_A(string, STRING), "String Is_A String.");
     TEST_TRUE(runner, Str_Is_A(string, OBJ), "String Is_A Obj.");
-    TEST_TRUE(runner, str_class == STRING, "Get_Class");
+    TEST_TRUE(runner, str_class == STRING, "get_class");
     TEST_TRUE(runner, Str_Equals(Class_Get_Name(STRING), (Obj*)class_name),
               "Get_Class_Name");
 

--- a/runtime/core/Clownfish/Test/TestObj.c
+++ b/runtime/core/Clownfish/Test/TestObj.c
@@ -86,13 +86,13 @@ test_Equals(TestBatchRunner *runner) {
 }
 
 static void
-test_Is_A(TestBatchRunner *runner) {
+test_is_a(TestBatchRunner *runner) {
     String *string     = Str_new_from_trusted_utf8("", 0);
     Class  *str_class  = Str_get_class(string);
     String *class_name = Str_get_class_name(string);
 
-    TEST_TRUE(runner, Str_Is_A(string, STRING), "String Is_A String.");
-    TEST_TRUE(runner, Str_Is_A(string, OBJ), "String Is_A Obj.");
+    TEST_TRUE(runner, Str_is_a(string, STRING), "String is_a String.");
+    TEST_TRUE(runner, Str_is_a(string, OBJ), "String is_a Obj.");
     TEST_TRUE(runner, str_class == STRING, "get_class");
     TEST_TRUE(runner, Str_Equals(Class_Get_Name(STRING), (Obj*)class_name),
               "get_class_name");
@@ -122,7 +122,7 @@ S_verify_abstract_error(TestBatchRunner *runner, Err_Attempt_t routine,
     sprintf(message, "%s() is abstract", name);
     Err *error = Err_trap(routine, context);
     TEST_TRUE(runner, error != NULL
-              && Err_Is_A(error, ERR) 
+              && Err_is_a(error, ERR)
               && Str_Find_Utf8(Err_Get_Mess(error), "bstract", 7) != -1,
               message);
     DECREF(error);
@@ -145,7 +145,7 @@ TestObj_Run_IMP(TestObj *self, TestBatchRunner *runner) {
     test_refcounts(runner);
     test_To_String(runner);
     test_Equals(runner);
-    test_Is_A(runner);
+    test_is_a(runner);
     test_abstract_routines(runner);
 }
 

--- a/runtime/core/Clownfish/TestHarness/TestFormatter.c
+++ b/runtime/core/Clownfish/TestHarness/TestFormatter.c
@@ -76,7 +76,7 @@ TestFormatterCF_Batch_Prologue_IMP(TestFormatterCF *self, TestBatch *batch,
                                    uint32_t num_planned) {
     UNUSED_VAR(self);
     UNUSED_VAR(num_planned);
-    String *class_name = TestBatch_Get_Class_Name(batch);
+    String *class_name = TestBatch_get_class_name(batch);
     char *utf8 = Str_To_Utf8(class_name);
     printf("Running %s...\n", utf8);
     FREEMEM(utf8);

--- a/runtime/core/Clownfish/TestHarness/TestSuite.c
+++ b/runtime/core/Clownfish/TestHarness/TestSuite.c
@@ -67,7 +67,7 @@ TestSuite_Run_Batch_IMP(TestSuite *self, String *class_name,
     for (uint32_t i = 0; i < size; ++i) {
         TestBatch *batch = (TestBatch*)Vec_Fetch(self->batches, i);
 
-        if (Str_Equals(TestBatch_Get_Class_Name(batch), (Obj*)class_name)) {
+        if (Str_Equals(TestBatch_get_class_name(batch), (Obj*)class_name)) {
             TestBatchRunner *runner = TestBatchRunner_new(formatter);
             bool result = TestBatchRunner_Run_Batch(runner, batch);
             DECREF(runner);

--- a/runtime/core/Clownfish/Vector.c
+++ b/runtime/core/Clownfish/Vector.c
@@ -256,7 +256,7 @@ bool
 Vec_Equals_IMP(Vector *self, Obj *other) {
     Vector *twin = (Vector*)other;
     if (twin == self)             { return true; }
-    if (!Obj_Is_A(other, VECTOR)) { return false; }
+    if (!Obj_is_a(other, VECTOR)) { return false; }
     if (twin->size != self->size) {
         return false;
     }

--- a/runtime/go/clownfish/clownfish.go
+++ b/runtime/go/clownfish/clownfish.go
@@ -97,7 +97,7 @@ func CFStringToGo(ptr unsafe.Pointer) string {
 	if cfString == nil {
 		return ""
 	}
-	if !C.CFISH_Str_Is_A(cfString, C.CFISH_STRING) {
+	if !C.cfish_Str_is_a(cfString, C.CFISH_STRING) {
 		cfString := C.CFISH_Str_To_String(cfString)
 		defer C.cfish_dec_refcount(unsafe.Pointer(cfString))
 	}

--- a/runtime/perl/buildlib/Clownfish/Build/Binding.pm
+++ b/runtime/perl/buildlib/Clownfish/Build/Binding.pm
@@ -392,9 +392,6 @@ sub bind_obj {
         To_String
         Equals
     );
-    my @hand_rolled = qw(
-        Is_A
-    );
 
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
@@ -509,7 +506,7 @@ is_a(self, class_name)
 CODE:
 {
     cfish_Class *target = cfish_Class_fetch_class(class_name);
-    RETVAL = CFISH_Obj_Is_A(self, target);
+    RETVAL = cfish_Obj_is_a(self, target);
 }
 OUTPUT: RETVAL
 END_XS_CODE
@@ -522,7 +519,6 @@ END_XS_CODE
         alias  => 'DESTROY',
         method => 'Destroy',
     );
-    $binding->exclude_method($_) for @hand_rolled;
     $binding->append_xs($xs_code);
     $binding->set_pod_spec($pod_spec);
 

--- a/runtime/perl/buildlib/Clownfish/Build/Binding.pm
+++ b/runtime/perl/buildlib/Clownfish/Build/Binding.pm
@@ -486,6 +486,14 @@ END_DESCRIPTION
     my $xs_code = <<'END_XS_CODE';
 MODULE = Clownfish     PACKAGE = Clownfish::Obj
 
+SV*
+get_class(self)
+    cfish_Obj *self
+CODE:
+    cfish_Class *klass = cfish_Obj_get_class(self);
+    RETVAL = (SV*)CFISH_Class_To_Host(klass);
+OUTPUT: RETVAL
+
 bool
 is_a(self, class_name)
     cfish_Obj *self;

--- a/runtime/perl/buildlib/Clownfish/Build/Binding.pm
+++ b/runtime/perl/buildlib/Clownfish/Build/Binding.pm
@@ -494,6 +494,14 @@ CODE:
     RETVAL = (SV*)CFISH_Class_To_Host(klass);
 OUTPUT: RETVAL
 
+SV*
+get_class_name(self)
+    cfish_Obj *self
+CODE:
+    cfish_String *class_name = cfish_Obj_get_class_name(self);
+    RETVAL = cfish_XSBind_str_to_sv(aTHX_ class_name);
+OUTPUT: RETVAL
+
 bool
 is_a(self, class_name)
     cfish_Obj *self;

--- a/runtime/perl/t/binding/019-obj.t
+++ b/runtime/perl/t/binding/019-obj.t
@@ -16,7 +16,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 21;
+use Test::More tests => 24;
 
 package TestObj;
 use base qw( Clownfish::Obj );
@@ -84,6 +84,14 @@ my $frozen = freeze($fake);
 eval { thaw($frozen) };
 like( $@, qr/implement/,
     "thawing an Obj throws an exception rather than segfaults" );
+
+my $obj_class = $object->get_class;
+isa_ok( $obj_class, "Clownfish::Class",
+        "get_class returns a Clownfish::Class" );
+my $testobj_class = Clownfish::Class->fetch_class('TestObj');
+isa_ok( $testobj_class, "Clownfish::Class",
+        "fetch_class returns a Clownfish::Class" );
+is( $$obj_class, $$testobj_class, "get_class returns correct class" );
 
 ok( $object->is_a("Clownfish::Obj"),     "custom is_a correct" );
 ok( !$object->is_a("Clownfish::Object"), "custom is_a too long" );

--- a/runtime/perl/xs/XSBind.c
+++ b/runtime/perl/xs/XSBind.c
@@ -145,22 +145,22 @@ XSBind_cfish_to_perl(pTHX_ cfish_Obj *obj) {
     if (obj == NULL) {
         return newSV(0);
     }
-    else if (CFISH_Obj_Is_A(obj, CFISH_STRING)) {
+    else if (cfish_Obj_is_a(obj, CFISH_STRING)) {
         return XSBind_str_to_sv(aTHX_ (cfish_String*)obj);
     }
-    else if (CFISH_Obj_Is_A(obj, CFISH_BLOB)) {
+    else if (cfish_Obj_is_a(obj, CFISH_BLOB)) {
         return XSBind_blob_to_sv(aTHX_ (cfish_Blob*)obj);
     }
-    else if (CFISH_Obj_Is_A(obj, CFISH_BYTEBUF)) {
+    else if (cfish_Obj_is_a(obj, CFISH_BYTEBUF)) {
         return XSBind_bb_to_sv(aTHX_ (cfish_ByteBuf*)obj);
     }
-    else if (CFISH_Obj_Is_A(obj, CFISH_VECTOR)) {
+    else if (cfish_Obj_is_a(obj, CFISH_VECTOR)) {
         return S_cfish_array_to_perl_array(aTHX_ (cfish_Vector*)obj);
     }
-    else if (CFISH_Obj_Is_A(obj, CFISH_HASH)) {
+    else if (cfish_Obj_is_a(obj, CFISH_HASH)) {
         return S_cfish_hash_to_perl_hash(aTHX_ (cfish_Hash*)obj);
     }
-    else if (CFISH_Obj_Is_A(obj, CFISH_FLOATNUM)) {
+    else if (cfish_Obj_is_a(obj, CFISH_FLOATNUM)) {
         return newSVnv(CFISH_FloatNum_To_F64((cfish_FloatNum*)obj));
     }
     else if (obj == (cfish_Obj*)CFISH_TRUE) {
@@ -169,15 +169,15 @@ XSBind_cfish_to_perl(pTHX_ cfish_Obj *obj) {
     else if (obj == (cfish_Obj*)CFISH_FALSE) {
         return newSViv(0);
     }
-    else if (sizeof(IV) == 8 && CFISH_Obj_Is_A(obj, CFISH_INTNUM)) {
+    else if (sizeof(IV) == 8 && cfish_Obj_is_a(obj, CFISH_INTNUM)) {
         int64_t num = CFISH_IntNum_To_I64((cfish_IntNum*)obj);
         return newSViv((IV)num);
     }
-    else if (sizeof(IV) == 4 && CFISH_Obj_Is_A(obj, CFISH_INTEGER32)) {
+    else if (sizeof(IV) == 4 && cfish_Obj_is_a(obj, CFISH_INTEGER32)) {
         int32_t num = (int32_t)CFISH_Int32_To_I64((cfish_Integer32*)obj);
         return newSViv((IV)num);
     }
-    else if (sizeof(IV) == 4 && CFISH_Obj_Is_A(obj, CFISH_INTEGER64)) {
+    else if (sizeof(IV) == 4 && cfish_Obj_is_a(obj, CFISH_INTEGER64)) {
         int64_t num = CFISH_Int64_To_I64((cfish_Integer64*)obj);
         return newSVnv((double)num); // lossy
     }

--- a/runtime/ruby/ext/Bind.c
+++ b/runtime/ruby/ext/Bind.c
@@ -20,10 +20,10 @@
 
 VALUE
 Bind_cfish_to_ruby(cfish_Obj *obj) {
-  if (CFISH_Obj_Is_A(obj, CFISH_STRING)) {
+  if (cfish_Obj_is_a(obj, CFISH_STRING)) {
       return Bind_str_to_ruby((cfish_String*)obj);
   }
-  else if (CFISH_Obj_Is_A(obj, CFISH_VECTOR)) {
+  else if (cfish_Obj_is_a(obj, CFISH_VECTOR)) {
       return S_cfish_array_to_ruby_array((cfish_Vector*)obj);
   }
 }


### PR DESCRIPTION
Second version of the pull request that adds type-safe wrappers for `get_class`, `get_class_name`, and `is_a` for each class. I chose lowercase names like `Str_is_a` because I find them easier to read and write. I'm aware that this could result in a name clash if someone decides to implement an inert function like `is_a` in a class. But this would be a really bad idea anyway, so I don't think it's a problem.