### PR TITLE
CLOWNFISH-32 Go constructor autogen

### DIFF
--- a/compiler/src/CFCGo.c
+++ b/compiler/src/CFCGo.c
@@ -232,6 +232,7 @@ S_gen_autogen_go(CFCGo *self, CFCParcel *parcel) {
     CFCGoClass **registry = CFCGoClass_registry();
     char *type_decs   = CFCUtil_strdup("");
     char *boilerplate = CFCUtil_strdup("");
+    char *ctors       = CFCUtil_strdup("");
     char *meth_defs   = CFCUtil_strdup("");
 
     for (int i = 0; registry[i] != NULL; i++) {
@@ -250,6 +251,10 @@ S_gen_autogen_go(CFCGo *self, CFCParcel *parcel) {
         boilerplate = CFCUtil_cat(boilerplate, boiler_code, "\n", NULL);
         FREEMEM(boiler_code);
 
+        char *ctor_code = CFCGoClass_gen_ctors(class_binding);
+        ctors = CFCUtil_cat(ctors, ctor_code, "\n", NULL);
+        FREEMEM(ctor_code);
+
         char *glue = CFCGoClass_gen_meth_glue(class_binding);
         meth_defs = CFCUtil_cat(meth_defs, glue, "\n", NULL);
         FREEMEM(glue);
@@ -264,15 +269,20 @@ S_gen_autogen_go(CFCGo *self, CFCParcel *parcel) {
         "\n"
         "%s\n"
         "\n"
+        "// Constructors.\n"
+        "\n"
+        "%s\n"
+        "\n"
         "// Method bindings.\n"
         "\n"
         "%s\n"
         "\n"
         ;
     char *content
-        = CFCUtil_sprintf(pattern, type_decs, boilerplate, meth_defs);
+        = CFCUtil_sprintf(pattern, type_decs, boilerplate, ctors, meth_defs);
 
     FREEMEM(meth_defs);
+    FREEMEM(ctors);
     FREEMEM(boilerplate);
     FREEMEM(type_decs);
     return content;

--- a/compiler/src/CFCGoClass.c
+++ b/compiler/src/CFCGoClass.c
@@ -259,6 +259,11 @@ CFCGoClass_boilerplate_funcs(CFCGoClass *self) {
     return content;
 }
 
+char*
+CFCGoClass_gen_ctors(CFCGoClass *self) {
+    return CFCUtil_strdup("");
+}
+
 static void
 S_lazy_init_method_bindings(CFCGoClass *self) {
     if (self->method_bindings) {

--- a/compiler/src/CFCGoClass.c
+++ b/compiler/src/CFCGoClass.c
@@ -17,6 +17,11 @@
 #include <string.h>
 #include <stdlib.h>
 
+#ifndef true
+#define true 1
+#define false 0
+#endif
+
 #define CFC_NEED_BASE_STRUCT_DEF
 #include "CFCBase.h"
 #include "CFCGoClass.h"
@@ -29,6 +34,7 @@
 #include "CFCSymbol.h"
 #include "CFCVariable.h"
 #include "CFCType.h"
+#include "CFCGoFunc.h"
 #include "CFCGoMethod.h"
 #include "CFCGoTypeMap.h"
 
@@ -40,6 +46,7 @@ struct CFCGoClass {
     CFCGoMethod **method_bindings;
     size_t num_bound;
     int suppress_struct;
+    int suppress_ctor;
 };
 
 static CFCGoClass **registry = NULL;
@@ -259,9 +266,44 @@ CFCGoClass_boilerplate_funcs(CFCGoClass *self) {
     return content;
 }
 
+
 char*
 CFCGoClass_gen_ctors(CFCGoClass *self) {
-    return CFCUtil_strdup("");
+    CFCFunction *ctor_func = CFCClass_function(self->client, "new");
+    if (self->suppress_ctor
+        || !ctor_func
+        || !CFCFunction_public(ctor_func)
+        || !CFCFunction_can_be_bound(ctor_func)
+       ) {
+        return CFCUtil_strdup("");
+    }
+    CFCParcel    *parcel     = CFCClass_get_parcel(self->client);
+    CFCParamList *param_list = CFCFunction_get_param_list(ctor_func);
+    CFCType      *ret_type   = CFCFunction_get_return_type(ctor_func);
+    const char   *struct_sym = CFCClass_get_struct_sym(self->client);
+    char         *name       = CFCUtil_sprintf("New%s", struct_sym);
+    char         *cfunc  = CFCFunction_full_func_sym(ctor_func, self->client);
+    char         *cfargs = CFCGoFunc_ctor_cfargs(parcel, param_list);
+    char *first_line
+        = CFCGoFunc_ctor_start(parcel, name, param_list, ret_type);
+    char *ret_statement
+        = CFCGoFunc_return_statement(parcel, ret_type, "retvalCF");
+
+    char pattern[] =
+        "%s"
+        "\tretvalCF := C.%s(%s)\n"
+        "%s"
+        "}\n"
+        ;
+    char *content = CFCUtil_sprintf(pattern, first_line, cfunc,
+                                    cfargs, ret_statement);
+
+    FREEMEM(ret_statement);
+    FREEMEM(cfargs);
+    FREEMEM(cfunc);
+    FREEMEM(first_line);
+    FREEMEM(name);
+    return content;
 }
 
 static void
@@ -362,5 +404,10 @@ CFCGoClass_spec_method(CFCGoClass *self, const char *name, const char *sig) {
 void
 CFCGoClass_set_suppress_struct(CFCGoClass *self, int suppress_struct) {
     self->suppress_struct = !!suppress_struct;
+}
+
+void
+CFCGoClass_set_suppress_ctor(CFCGoClass *self, int suppress_ctor) {
+    self->suppress_ctor = !!suppress_ctor;
 }
 

--- a/compiler/src/CFCGoClass.h
+++ b/compiler/src/CFCGoClass.h
@@ -71,6 +71,9 @@ char*
 CFCGoClass_boilerplate_funcs(CFCGoClass *self);
 
 char*
+CFCGoClass_gen_ctors(CFCGoClass *self);
+
+char*
 CFCGoClass_gen_meth_glue(CFCGoClass *self);
 
 void

--- a/compiler/src/CFCGoClass.h
+++ b/compiler/src/CFCGoClass.h
@@ -82,6 +82,9 @@ CFCGoClass_spec_method(CFCGoClass *self, const char *name, const char *sig);
 void
 CFCGoClass_set_suppress_struct(CFCGoClass *self, int suppress_struct);
 
+void
+CFCGoClass_set_suppress_ctor(CFCGoClass *self, int suppress_ctor);
+
 #ifdef __cplusplus
 }
 #endif

--- a/compiler/src/CFCGoFunc.c
+++ b/compiler/src/CFCGoFunc.c
@@ -113,6 +113,13 @@ CFCGoFunc_meth_start(CFCParcel *parcel, const char *name, CFCClass *invoker,
                         IS_METHOD);
 }
 
+char*
+CFCGoFunc_ctor_start(CFCParcel *parcel, const char *name,
+                     CFCParamList *param_list, CFCType *return_type) {
+    return S_prep_start(parcel, name, NULL, param_list, return_type,
+                        IS_CTOR);
+}
+
 static char*
 S_prep_cfargs(CFCParcel *parcel, CFCClass *invoker,
                       CFCParamList *param_list, int targ) {
@@ -177,6 +184,11 @@ char*
 CFCGoFunc_meth_cfargs(CFCParcel *parcel, CFCClass *invoker,
                       CFCParamList *param_list) {
     return S_prep_cfargs(parcel, invoker, param_list, IS_METHOD);
+}
+
+char*
+CFCGoFunc_ctor_cfargs(CFCParcel *parcel, CFCParamList *param_list) {
+    return S_prep_cfargs(parcel, NULL, param_list, IS_CTOR);
 }
 
 char*

--- a/compiler/src/CFCGoFunc.c
+++ b/compiler/src/CFCGoFunc.c
@@ -52,15 +52,14 @@ CFCGoFunc_go_meth_name(const char *orig) {
     return go_name;
 }
 
-char*
-CFCGoFunc_func_start(CFCParcel *parcel, const char *name, CFCClass *invoker,
-                     CFCParamList *param_list, CFCType *return_type,
-                     int is_method) {
+static char*
+S_prep_start(CFCParcel *parcel, const char *name, CFCClass *invoker,
+             CFCParamList *param_list, CFCType *return_type, int targ) {
     CFCVariable **param_vars = CFCParamList_get_variables(param_list);
     char *invocant;
     char go_name[GO_NAME_BUF_SIZE];
 
-    if (is_method) {
+    if (targ == IS_METHOD) {
         const char *struct_sym = CFCClass_get_struct_sym(invoker);
         CFCGoTypeMap_go_meth_receiever(struct_sym, param_list, go_name,
                                        GO_NAME_BUF_SIZE);
@@ -71,7 +70,7 @@ CFCGoFunc_func_start(CFCParcel *parcel, const char *name, CFCClass *invoker,
     }
 
     char *params = CFCUtil_strdup("");
-    int start = is_method ? 1 : 0;
+    int start = targ == IS_METHOD ? 1 : 0;
     for (int i = start; param_vars[i] != NULL; i++) {
         CFCVariable *var = param_vars[i];
         CFCType *type = CFCVariable_get_type(var);
@@ -105,6 +104,13 @@ CFCGoFunc_func_start(CFCParcel *parcel, const char *name, CFCClass *invoker,
     FREEMEM(params);
     FREEMEM(ret_type_str);
     return content;
+}
+
+char*
+CFCGoFunc_meth_start(CFCParcel *parcel, const char *name, CFCClass *invoker,
+                     CFCParamList *param_list, CFCType *return_type) {
+    return S_prep_start(parcel, name, invoker, param_list, return_type,
+                        IS_METHOD);
 }
 
 static char*

--- a/compiler/src/CFCGoFunc.h
+++ b/compiler/src/CFCGoFunc.h
@@ -32,10 +32,10 @@ char*
 CFCGoFunc_go_meth_name(const char *orig);
 
 char*
-CFCGoFunc_func_start(struct CFCParcel *parcel, const char *name,
+CFCGoFunc_meth_start(struct CFCParcel *parcel, const char *name,
                      struct CFCClass *invoker,
                      struct CFCParamList *param_list,
-                     struct CFCType *return_type, int is_method);
+                     struct CFCType *return_type);
 
 /** Convert Go method arguments to comma-separated Clownfish-flavored C
  * arguments, to be passed to a Clownfish method.

--- a/compiler/src/CFCGoFunc.h
+++ b/compiler/src/CFCGoFunc.h
@@ -37,11 +37,23 @@ CFCGoFunc_meth_start(struct CFCParcel *parcel, const char *name,
                      struct CFCParamList *param_list,
                      struct CFCType *return_type);
 
+char*
+CFCGoFunc_ctor_start(struct CFCParcel *parcel, const char *name,
+                     struct CFCParamList *param_list,
+                     struct CFCType *return_type);
+
 /** Convert Go method arguments to comma-separated Clownfish-flavored C
  * arguments, to be passed to a Clownfish method.
  */
 char*
 CFCGoFunc_meth_cfargs(struct CFCParcel *parcel, struct CFCClass *invoker,
+                      struct CFCParamList *param_list);
+
+/** Convert Go method arguments to comma-separated Clownfish-flavored C
+ * arguments, to be passed to a Clownfish `new` function.
+ */
+char*
+CFCGoFunc_ctor_cfargs(struct CFCParcel *parcel,
                       struct CFCParamList *param_list);
 
 /** Generate a Go return statement which maps from a CGO Clownfish type to a

--- a/compiler/src/CFCGoFunc.h
+++ b/compiler/src/CFCGoFunc.h
@@ -37,6 +37,13 @@ CFCGoFunc_func_start(struct CFCParcel *parcel, const char *name,
                      struct CFCParamList *param_list,
                      struct CFCType *return_type, int is_method);
 
+/** Convert Go method arguments to comma-separated Clownfish-flavored C
+ * arguments, to be passed to a Clownfish method.
+ */
+char*
+CFCGoFunc_meth_cfargs(struct CFCParcel *parcel, struct CFCClass *invoker,
+                      struct CFCParamList *param_list);
+
 /** Generate a Go return statement which maps from a CGO Clownfish type to a
  * Go type.
  *

--- a/compiler/src/CFCGoMethod.c
+++ b/compiler/src/CFCGoMethod.c
@@ -144,8 +144,8 @@ CFCGoMethod_func_def(CFCGoMethod *self, CFCClass *invoker) {
     CFCParamList *param_list = CFCMethod_get_param_list(novel_method);
     CFCType      *ret_type   = CFCMethod_get_return_type(novel_method);
     char *name = CFCGoFunc_go_meth_name(CFCMethod_get_name(novel_method));
-    char *first_line = CFCGoFunc_func_start(parcel, name, invoker,
-                                            param_list, ret_type, true);
+    char *first_line = CFCGoFunc_meth_start(parcel, name, invoker,
+                                            param_list, ret_type);
     char *cfunc;
     if (CFCMethod_novel(self->method) && CFCMethod_final(self->method)) {
         cfunc = CFCUtil_strdup(CFCMethod_imp_func(self->method, invoker));

--- a/runtime/core/Clownfish/Err.cfh
+++ b/runtime/core/Clownfish/Err.cfh
@@ -43,10 +43,10 @@ public class Clownfish::Err inherits Clownfish::Obj {
     inert void
     init_class();
 
-    inert incremented Err*
+    public inert incremented Err*
     new(decremented String *mess);
 
-    inert Err*
+    public inert Err*
     init(Err *self, decremented String *mess);
 
     public void

--- a/runtime/go/clownfish/clownfish.go
+++ b/runtime/go/clownfish/clownfish.go
@@ -106,14 +106,6 @@ func CFStringToGo(ptr unsafe.Pointer) string {
 	return C.GoStringN(data, size)
 }
 
-func NewErr(mess string) Err {
-	str := C.CString(mess)
-	len := C.size_t(len(mess))
-	messC := C.cfish_Str_new_steal_utf8(str, len)
-	cfObj := C.cfish_Err_new(messC)
-	return WRAPErr(unsafe.Pointer(cfObj))
-}
-
 func (e *ErrIMP) Error() string {
 	mess := C.CFISH_Err_Get_Mess((*C.cfish_Err)(unsafe.Pointer(e.ref)))
 	return CFStringToGo(unsafe.Pointer(mess))


### PR DESCRIPTION
Autogenerate Go constructor bindings.

The constructors follow Go naming conventions, following the proof-of-concept bindings: `NewFoo()`

Subtyping is not supported.  Under the hood, we use the inert function `new` when available -- unlike the Perl bindings, which use `init`.