### PR TITLE
CLOWNFISH-58 Hash Store nullable

### DIFF
--- a/runtime/core/Clownfish/Hash.cfh
+++ b/runtime/core/Clownfish/Hash.cfh
@@ -55,11 +55,11 @@ public final class Clownfish::Hash inherits Clownfish::Obj {
     /** Store a key-value pair.
      */
     public void
-    Store(Hash *self, String *key, decremented Obj *value);
+    Store(Hash *self, String *key, decremented nullable Obj *value);
 
     public void
     Store_Utf8(Hash *self, const char *str, size_t len,
-               decremented Obj *value);
+               decremented nullable Obj *value);
 
     /** Fetch the value associated with `key`.
      *

--- a/runtime/core/Clownfish/Test/TestHash.c
+++ b/runtime/core/Clownfish/Test/TestHash.c
@@ -122,6 +122,14 @@ test_Store_and_Fetch(TestBatchRunner *runner) {
     TEST_TRUE(runner, Hash_Fetch(hash, twenty) == NULL, "Clear");
     TEST_TRUE(runner, Hash_Get_Size(hash) == 0, "size is 0 after Clear");
 
+    Hash_Clear(hash);
+    Hash_Store(hash, forty, NULL);
+    TEST_TRUE(runner, Hash_Fetch(hash, forty) == NULL, "Store NULL");
+    TEST_TRUE(runner, Hash_Get_Size(hash) == 1, "Size after Store NULL");
+    TEST_TRUE(runner, Hash_Delete(hash, forty) == NULL, "Delete NULL value");
+    TEST_TRUE(runner, Hash_Get_Size(hash) == 0,
+              "Size after Deleting NULL val");
+
     DECREF(hash);
     DECREF(dupe);
     DECREF(got);
@@ -239,7 +247,7 @@ test_store_skips_tombstone(TestBatchRunner *runner) {
 
 void
 TestHash_Run_IMP(TestHash *self, TestBatchRunner *runner) {
-    TestBatchRunner_Plan(runner, (TestBatch*)self, 26);
+    TestBatchRunner_Plan(runner, (TestBatch*)self, 30);
     srand((unsigned int)time((time_t*)NULL));
     test_Equals(runner);
     test_Store_and_Fetch(runner);

--- a/runtime/perl/buildlib/Clownfish/Build/Binding.pm
+++ b/runtime/perl/buildlib/Clownfish/Build/Binding.pm
@@ -302,13 +302,16 @@ CODE:
 OUTPUT: RETVAL
 
 void
-store(self, key, value);
+store(self, key, value_sv);
     cfish_Hash         *self;
     cfish_String *key;
-    cfish_Obj          *value;
+    SV           *value_sv;
 PPCODE:
 {
-    if (value) { CFISH_INCREF(value); }
+    cfish_Obj *value
+        = (cfish_Obj*)XSBind_maybe_sv_to_cfish_obj(aTHX_ value_sv, CFISH_OBJ,
+                                                   CFISH_ALLOCA_OBJ(CFISH_STRING));
+    if (value) { value = CFISH_INCREF(value); }
     CFISH_Hash_Store_IMP(self, key, value);
 }
 END_XS_CODE

--- a/runtime/perl/t/binding/017-hash.t
+++ b/runtime/perl/t/binding/017-hash.t
@@ -16,7 +16,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 2;
+use Test::More tests => 4;
 use Clownfish qw( to_perl to_clownfish );
 
 my $hash = Clownfish::Hash->new( capacity => 10 );
@@ -25,6 +25,11 @@ $hash->store( "baz", Clownfish::String->new("banana") );
 
 ok( !defined( $hash->fetch("blah") ),
     "fetch for a non-existent key returns undef" );
+
+$hash->clear();
+$hash->store( "nada", undef );
+ok( !defined($hash->fetch("nada")), "store/fetch undef value" );
+is( $hash->get_size, 1, "size after storing undef value" );
 
 my %hash_with_utf8_keys = ( "\x{263a}" => "foo" );
 my $round_tripped = to_perl( to_clownfish( \%hash_with_utf8_keys ) );


### PR DESCRIPTION
The signature for Hash's Store() method should accept `nullable` values.  The implementation is already safe for use with NULL values, and we had already discussed that we needed `Has_Key` to identify keys mapped to NULL. 