### PR TITLE
CLOWNFISH-61 Run core tests under Go

### DIFF
--- a/runtime/go/build.go
+++ b/runtime/go/build.go
@@ -111,7 +111,8 @@ func configure() {
 	}
 	if !current(charmonizerEXE, charmonyH) {
 		runCommand("./charmonizer", "--cc=cc", "--enable-c", "--host=go",
-			"--enable-makefile", "--", "-std=gnu99", "-O2")
+			"--enable-makefile", "--disable-threads", "--", "-std=gnu99",
+			"-O2")
 	}
 }
 

--- a/runtime/go/clownfish/clownfish.go
+++ b/runtime/go/clownfish/clownfish.go
@@ -22,6 +22,9 @@ package clownfish
 
 #include "charmony.h"
 
+#include "cfish_parcel.h"
+#include "testcfish_parcel.h"
+
 #include "Clownfish/Obj.h"
 #include "Clownfish/Err.h"
 #include "Clownfish/Class.h"
@@ -85,6 +88,7 @@ var wrapReg *map[unsafe.Pointer]WrapFunc
 func init() {
 	C.GoCfish_glue_exported_symbols()
 	C.cfish_bootstrap_parcel()
+	C.testcfish_bootstrap_parcel()
 	initWRAP()
 }
 

--- a/runtime/go/clownfish/test.go
+++ b/runtime/go/clownfish/test.go
@@ -1,0 +1,28 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package clownfish
+
+/*
+#include "Clownfish/Test.h"
+*/
+import "C"
+import "unsafe"
+
+func createTestSuite() TestSuite {
+	ts := C.testcfish_Test_create_test_suite()
+	return WRAPAny(unsafe.Pointer(ts)).(TestSuite)
+}

--- a/runtime/go/clownfish/test_test.go
+++ b/runtime/go/clownfish/test_test.go
@@ -1,0 +1,28 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package clownfish
+
+import "testing"
+
+func TestRunCoreTests(t *testing.T) {
+	suite := createTestSuite()
+	formatter := NewTestFormatterCF()
+	success := suite.RunAllBatches(formatter)
+	if !success {
+		t.Error("Core tests failed")
+	}
+}

--- a/runtime/go/ext/testclownfish.c
+++ b/runtime/go/ext/testclownfish.c
@@ -1,0 +1,35 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define CFISH_USE_SHORT_NAMES
+
+#include "Clownfish/TestHarness/TestUtils.h"
+
+void*
+TestUtils_clone_host_runtime() {
+    return NULL;
+}
+
+void
+TestUtils_set_host_runtime(void *runtime) {
+    UNUSED_VAR(runtime);
+}
+
+void
+TestUtils_destroy_host_runtime(void *runtime) {
+    UNUSED_VAR(runtime);
+}
+


### PR DESCRIPTION
Run the core tests under the Go bindings.

Some kludges are necessary to suppress failures in Err, whose usage of thread-local storage is not compatible with Go's concurrency model.