### PR TITLE
CLOWNFISH-63 Don't export private methods via Go v2

### DIFF
--- a/compiler/src/CFCGoFunc.c
+++ b/compiler/src/CFCGoFunc.c
@@ -17,6 +17,8 @@
 
 #include <string.h>
 #include <stdio.h>
+#include <ctype.h>
+
 #include "CFCGoFunc.h"
 #include "CFCGoTypeMap.h"
 #include "CFCBase.h"
@@ -42,9 +44,12 @@ enum {
 };
 
 char*
-CFCGoFunc_go_meth_name(const char *orig) {
+CFCGoFunc_go_meth_name(const char *orig, int is_public) {
     char *go_name = CFCUtil_strdup(orig);
-    for (int i = 0, j = 0, max = strlen(go_name) + 1; i < max; i++) {
+    if (!is_public) {
+        go_name[0] = tolower(go_name[0]);
+    }
+    for (int i = 1, j = 1, max = strlen(go_name) + 1; i < max; i++) {
         if (go_name[i] != '_') {
             go_name[j++] = go_name[i];
         }

--- a/compiler/src/CFCGoFunc.h
+++ b/compiler/src/CFCGoFunc.h
@@ -29,7 +29,7 @@ struct CFCClass;
 struct CFCParamList;
 
 char*
-CFCGoFunc_go_meth_name(const char *orig);
+CFCGoFunc_go_meth_name(const char *orig, int is_public);
 
 char*
 CFCGoFunc_meth_start(struct CFCParcel *parcel, const char *name,

--- a/compiler/src/CFCGoMethod.c
+++ b/compiler/src/CFCGoMethod.c
@@ -93,7 +93,8 @@ S_lazy_init_sig(CFCGoMethod *self, CFCClass *invoker) {
     CFCMethod *method = self->method;
     CFCParcel *parcel = CFCClass_get_parcel(invoker);
     CFCType *return_type = CFCMethod_get_return_type(method);
-    char *name = CFCGoFunc_go_meth_name(CFCMethod_get_name(method));
+    char *name = CFCGoFunc_go_meth_name(CFCMethod_get_name(method),
+                                        CFCMethod_public(method));
     char *go_ret_type = CFCType_is_void(return_type)
                         ? CFCUtil_strdup("")
                         : CFCGoTypeMap_go_type_name(return_type, parcel);
@@ -143,7 +144,8 @@ CFCGoMethod_func_def(CFCGoMethod *self, CFCClass *invoker) {
     CFCParcel    *parcel     = CFCClass_get_parcel(invoker);
     CFCParamList *param_list = CFCMethod_get_param_list(novel_method);
     CFCType      *ret_type   = CFCMethod_get_return_type(novel_method);
-    char *name = CFCGoFunc_go_meth_name(CFCMethod_get_name(novel_method));
+    char *name = CFCGoFunc_go_meth_name(CFCMethod_get_name(novel_method),
+                                        CFCMethod_public(novel_method));
     char *first_line = CFCGoFunc_meth_start(parcel, name, invoker,
                                             param_list, ret_type);
     char *cfunc;

--- a/runtime/core/Clownfish/TestHarness/TestSuite.cfh
+++ b/runtime/core/Clownfish/TestHarness/TestSuite.cfh
@@ -30,13 +30,13 @@ class Clownfish::TestHarness::TestSuite inherits Clownfish::Obj {
     public void
     Destroy(TestSuite *self);
 
-    void
+    public void
     Add_Batch(TestSuite *self, decremented TestBatch *batch);
 
-    bool
+    public bool
     Run_Batch(TestSuite *self, String *class_name, TestFormatter *formatter);
 
-    bool
+    public bool
     Run_All_Batches(TestSuite *self, TestFormatter *formatter);
 }
 

--- a/runtime/go/clownfish/bytebuf_test.go
+++ b/runtime/go/clownfish/bytebuf_test.go
@@ -22,8 +22,8 @@ import "reflect"
 func TestByteBufCat(t *testing.T) {
 	bb := NewByteBuf(0)
 	content := []byte("foo")
-	bb.Cat(content)
-	if got := bb.YieldBlob(); !reflect.DeepEqual(got, content) {
+	bb.cat(content)
+	if got := bb.yieldBlob(); !reflect.DeepEqual(got, content) {
 		t.Errorf("Expected %v, got %v", content, got)
 	}
 }
@@ -31,20 +31,20 @@ func TestByteBufCat(t *testing.T) {
 func TestByteBufSetSizeGetSize(t *testing.T) {
 	bb := NewByteBuf(0)
 	content := []byte("abc")
-	bb.Cat(content)
-	bb.SetSize(2)
-	if got := bb.GetSize(); got != 2 {
+	bb.cat(content)
+	bb.setSize(2)
+	if got := bb.getSize(); got != 2 {
 		t.Errorf("Expected size 2, got %d", got)
 	}
 	expected := []byte("ab")
-	if got := bb.YieldBlob(); !reflect.DeepEqual(got, expected) {
+	if got := bb.yieldBlob(); !reflect.DeepEqual(got, expected) {
 		t.Errorf("Expected %v, got %v", expected, got)
 	}
 }
 
 func TestByteBufGetCapacity(t *testing.T) {
 	bb := NewByteBuf(5)
-	if cap := bb.GetCapacity(); cap < 5 {
+	if cap := bb.getCapacity(); cap < 5 {
 		t.Errorf("Expected at least 5, got %d", cap)
 	}
 }
@@ -52,10 +52,10 @@ func TestByteBufGetCapacity(t *testing.T) {
 func TestByteBufMimic(t *testing.T) {
 	bb := NewByteBuf(0)
 	content := []byte("foo")
-	bb.Cat(content)
+	bb.cat(content)
 	other := NewByteBuf(0)
 	other.Mimic(bb)
-	if got := other.YieldBlob(); !reflect.DeepEqual(got, content) {
+	if got := other.yieldBlob(); !reflect.DeepEqual(got, content) {
 		t.Errorf("Expected %v, got %v", content, got)
 	}
 }
@@ -64,12 +64,12 @@ func TestByteBufEquals(t *testing.T) {
 	bb := NewByteBuf(0)
 	other := NewByteBuf(0)
 	content := []byte("foo")
-	bb.Cat(content)
-	other.Cat(content)
+	bb.cat(content)
+	other.cat(content)
 	if !bb.Equals(other) {
 		t.Errorf("Equals against equal ByteBuf")
 	}
-	other.SetSize(2)
+	other.setSize(2)
 	if bb.Equals(other) {
 		t.Errorf("Equals against non-equal ByteBuf")
 	}
@@ -81,9 +81,9 @@ func TestByteBufEquals(t *testing.T) {
 func TestByteBufClone(t *testing.T) {
 	content := []byte("foo")
 	bb := NewByteBuf(0)
-	bb.Cat(content)
+	bb.cat(content)
 	clone := bb.Clone().(ByteBuf)
-	if got := clone.YieldBlob(); !reflect.DeepEqual(got, content) {
+	if got := clone.yieldBlob(); !reflect.DeepEqual(got, content) {
 		t.Errorf("Expected %v, got %v", content, got)
 	}
 }
@@ -92,12 +92,12 @@ func TestByteBufCompareTo(t *testing.T) {
 	bb := NewByteBuf(0)
 	other := NewByteBuf(0)
 	content := []byte("foo")
-	bb.Cat(content)
-	other.Cat(content)
+	bb.cat(content)
+	other.cat(content)
 	if got := bb.CompareTo(other); got != 0 {
 		t.Errorf("CompareTo equal, got %d", got)
 	}
-	other.SetSize(2)
+	other.setSize(2)
 	if got := bb.CompareTo(other); got <= 0 {
 		t.Errorf("CompareTo lesser, got %d", got)
 	}

--- a/runtime/go/clownfish/charbuf_test.go
+++ b/runtime/go/clownfish/charbuf_test.go
@@ -20,7 +20,7 @@ import "testing"
 
 func TestCharBufCat(t *testing.T) {
 	cb := NewCharBuf(0)
-	cb.Cat("foo")
+	cb.cat("foo")
 	if got := cb.ToString(); got != "foo" {
 		t.Errorf("Expected foo, got %v", got)
 	}
@@ -29,7 +29,7 @@ func TestCharBufCat(t *testing.T) {
 func TestCharBufMimic(t *testing.T) {
 	cb := NewCharBuf(0)
 	other := NewCharBuf(0)
-	other.Cat("foo")
+	other.cat("foo")
 	cb.Mimic(other)
 	if got := cb.ToString(); got != "foo" {
 		t.Errorf("Expected foo, got %v", got)
@@ -38,7 +38,7 @@ func TestCharBufMimic(t *testing.T) {
 
 func TestCharBufCatChar(t *testing.T) {
 	cb := NewCharBuf(0)
-	cb.CatChar('x')
+	cb.catChar('x')
 	if got := cb.ToString(); got != "x" {
 		t.Errorf("Expected x, got %v", got)
 	}
@@ -46,9 +46,9 @@ func TestCharBufCatChar(t *testing.T) {
 
 func TestCharBufSetSizeGetSize(t *testing.T) {
 	cb := NewCharBuf(0)
-	cb.Cat("abc")
-	cb.SetSize(2)
-	if got := cb.GetSize(); got != 2 {
+	cb.cat("abc")
+	cb.setSize(2)
+	if got := cb.getSize(); got != 2 {
 		t.Errorf("Size should be 2 but got %d", got)
 	}
 	if got := cb.ToString(); got != "ab" {
@@ -58,7 +58,7 @@ func TestCharBufSetSizeGetSize(t *testing.T) {
 
 func TestCharBufClone(t *testing.T) {
 	cb := NewCharBuf(0)
-	cb.Cat("foo")
+	cb.cat("foo")
 	clone := cb.Clone()
 	if got := clone.ToString(); got != "foo" {
 		t.Errorf("Expected foo, got %v", got)
@@ -67,7 +67,7 @@ func TestCharBufClone(t *testing.T) {
 
 func TestCharBufYieldString(t *testing.T) {
 	cb := NewCharBuf(0)
-	cb.Cat("foo")
+	cb.cat("foo")
 	if got := cb.YieldString(); got != "foo" {
 		t.Errorf("Should yield foo, got %v", got)
 	}

--- a/runtime/go/clownfish/class_test.go
+++ b/runtime/go/clownfish/class_test.go
@@ -37,8 +37,8 @@ func TestClassGetParent(t *testing.T) {
 func TestClassGetObjAllocSize(t *testing.T) {
 	intClass := FetchClass("Clownfish::Integer")
 	classClass := FetchClass("Clownfish::Class")
-	if intClass.GetObjAllocSize() >= classClass.GetObjAllocSize() {
-		t.Error("Unexpected result for GetObjAllocSize")
+	if intClass.getObjAllocSize() >= classClass.getObjAllocSize() {
+		t.Error("Unexpected result for getObjAllocSize")
 	}
 }
 

--- a/runtime/go/clownfish/hash_test.go
+++ b/runtime/go/clownfish/hash_test.go
@@ -98,8 +98,8 @@ func TestHashValues(t *testing.T) {
 
 func TestGetCapacity(t *testing.T) {
 	hash := NewHash(1)
-	if cap := hash.GetCapacity(); cap <= 1 {
-		t.Errorf("Unexpected value for GetCapacity: %d", cap)
+	if cap := hash.getCapacity(); cap <= 1 {
+		t.Errorf("Unexpected value for getCapacity: %d", cap)
 	}
 }
 

--- a/runtime/go/clownfish/method_test.go
+++ b/runtime/go/clownfish/method_test.go
@@ -21,7 +21,7 @@ import "unsafe"
 
 func TestMethodGetName(t *testing.T) {
 	meth := NewMethod("Do_Stuff", unsafe.Pointer(nil), 32)
-	if name := meth.GetName(); name != "Do_Stuff" {
+	if name := meth.getName(); name != "Do_Stuff" {
 		t.Errorf("Expected \"Do_Stuff\", got %s", name)
 	}
 }
@@ -29,8 +29,8 @@ func TestMethodGetName(t *testing.T) {
 func TestMethodGetHostAlias(t *testing.T) {
 	meth := NewMethod("Do_Stuff", unsafe.Pointer(nil), 32)
 	alias := "GetStuffDone"
-	meth.SetHostAlias(alias)
-	if got := meth.GetHostAlias(); got != alias {
+	meth.setHostAlias(alias)
+	if got := meth.getHostAlias(); got != alias {
 		t.Errorf("Expected %v, got %v", alias, got)
 	}
 }
@@ -38,14 +38,14 @@ func TestMethodGetHostAlias(t *testing.T) {
 func TestMethodHostName(t *testing.T) {
 	meth := NewMethod("Do_Stuff", unsafe.Pointer(nil), 32)
 	expected := "DoStuff"
-	if hostName := meth.HostName(); hostName != expected {
+	if hostName := meth.hostName(); hostName != expected {
 		t.Errorf("Expected %v, got %v", expected, hostName)
 	}
 }
 
 func TestMethodIsExcludedFromHost(t *testing.T) {
 	meth := NewMethod("Do_Stuff", unsafe.Pointer(nil), 32)
-	if meth.IsExcludedFromHost() {
+	if meth.isExcludedFromHost() {
 		t.Errorf("Meth should not be excluded")
 	}
 }

--- a/runtime/go/clownfish/string_test.go
+++ b/runtime/go/clownfish/string_test.go
@@ -148,7 +148,7 @@ func TestStringClone(t *testing.T) {
 func TestStringHashSum(t *testing.T) {
 	// Test compilation only.
 	s := NewString("foo")
-	var _ uintptr = s.HashSum()
+	var _ uintptr = s.hashSum()
 }
 
 func TestStringToString(t *testing.T) {

--- a/runtime/go/clownfish/vector_test.go
+++ b/runtime/go/clownfish/vector_test.go
@@ -148,7 +148,7 @@ func TestVecGetSize(t *testing.T) {
 
 func TestVecGetCapacity(t *testing.T) {
 	vec := NewVector(10)
-	cap := vec.GetCapacity()
+	cap := vec.getCapacity()
 	if cap != 10 {
 		t.Errorf("Unexpected capacity: %v", cap)
 	}


### PR DESCRIPTION
Clownfish methods which are not marked as `public` should have the first letter of their Go method name downcased so that they are not exported by the Go package.

This pull requests differs from v1 in that it adds a missing include for ctype.h which caused an Appveyor CI failure.