### PR TITLE
CLOWNFISH-64 Autogenerate Perl subroutine code samples

### DIFF
--- a/compiler/src/CFCPerlPod.c
+++ b/compiler/src/CFCPerlPod.c
@@ -322,25 +322,7 @@ CFCPerlPod_gen_subroutine_pod(CFCFunction *func,
         CFCUtil_die("%s#%s is not public", class_name, alias);
     }
 
-    CFCParamList *param_list = CFCFunction_get_param_list(func);
-    int num_vars = (int)CFCParamList_num_vars(param_list);
-    char *pod = CFCUtil_sprintf("=head2 %s", alias);
-
-    // Build string summarizing arguments to use in header.
-    if (num_vars > 2 || (is_constructor && num_vars > 1)) {
-        pod = CFCUtil_cat(pod, "( I<[labeled params]> )\n\n", NULL);
-    }
-    else if (num_vars == 2) {
-        // Kill self param.
-        const char *name_list = CFCParamList_name_list(param_list);
-        const char *after_comma = strchr(name_list, ',') + 1;
-        while (isspace(*after_comma)) { after_comma++; }
-        pod = CFCUtil_cat(pod, "(", after_comma, ")\n\n", NULL);
-    }
-    else {
-        // num_args == 1, leave off 'self'.
-        pod = CFCUtil_cat(pod, "()\n\n", NULL);
-    }
+    char *pod = CFCUtil_sprintf("=head2 %s\n\n", alias);
 
     // Add code sample.
     if (!code_sample) {

--- a/compiler/src/CFCPerlPod.c
+++ b/compiler/src/CFCPerlPod.c
@@ -876,6 +876,16 @@ S_convert_link(cmark_node *link, CFCClass *doc_class, int header_level) {
                 perl_name[i] = tolower(perl_name[i]);
             }
 
+            // The Perl POD only contains sections for novel methods. Link
+            // to the class where the method is declared first.
+            if (type == CFC_URI_METHOD) {
+                CFCClass *parent = CFCClass_get_parent(klass);
+                while (parent && CFCClass_method(parent, name)) {
+                    klass = parent;
+                    parent = CFCClass_get_parent(klass);
+                }
+            }
+
             if (klass == doc_class) {
                 new_uri = CFCUtil_sprintf("/%s", perl_name);
             }

--- a/compiler/src/CFCPerlPod.c
+++ b/compiler/src/CFCPerlPod.c
@@ -871,22 +871,24 @@ S_convert_link(cmark_node *link, CFCClass *doc_class, int header_level) {
                 break;
             }
 
-            // TODO: Link to relevant POD section. This isn't easy because
-            // the section headers for functions also contain a description
-            // of the parameters.
+            char *perl_name = CFCUtil_strdup(name);
+            for (size_t i = 0; perl_name[i] != '\0'; ++i) {
+                perl_name[i] = tolower(perl_name[i]);
+            }
 
-            if (klass != doc_class) {
+            if (klass == doc_class) {
+                new_uri = CFCUtil_sprintf("/%s", perl_name);
+            }
+            else {
                 const char *class_name = CFCClass_get_name(klass);
-                new_uri = CFCUtil_strdup(class_name);
+                new_uri = CFCUtil_sprintf("%s/%s", class_name, perl_name);
             }
 
             if (text[0] == '\0') {
-                new_text = CFCUtil_sprintf("%s()", name);
-                for (size_t i = 0; new_text[i] != '\0'; ++i) {
-                    new_text[i] = tolower(new_text[i]);
-                }
+                new_text = CFCUtil_sprintf("%s()", perl_name);
             }
 
+            FREEMEM(perl_name);
             break;
         }
 

--- a/compiler/src/CFCPerlPod.c
+++ b/compiler/src/CFCPerlPod.c
@@ -557,7 +557,7 @@ S_camel_to_lower(const char *camel) {
         }
         alloc += 1;
     }
-    char *lower = MALLOCATE(alloc + 1);
+    char *lower = (char*)MALLOCATE(alloc + 1);
 
     lower[0] = tolower(camel[0]);
     size_t j = 1;

--- a/runtime/core/Clownfish/Class.cfh
+++ b/runtime/core/Clownfish/Class.cfh
@@ -47,9 +47,8 @@ public final class Clownfish::Class inherits Clownfish::Obj {
      * the supplied class name, it will be returned.  Otherwise, a new Class
      * will be created using [parent] as a base.
      *
-     * If [parent] is NULL, an attempt will be made to find it using
-     * [](.find_parent_class).  If the attempt fails, an error will
-     * result.
+     * If [parent] is NULL, an attempt will be made to find it.  If the
+     * attempt fails, an error will result.
      */
     public inert Class*
     singleton(String *class_name, Class *parent);


### PR DESCRIPTION
Now the generated POD looks like

    =head2 glean_query

        $searcher->glean_query($query);
        $searcher->glean_query();  # default: undef

    [...]

    =head2 hits

        $searcher->hits(
            query      => $obj,        # required
            offset     => $int,        # default: 0
            num_wanted => $int,        # default: 10
            sort_spec  => $sort_spec,  # default: undef
        );

    [...]

This also makes it possible to link to the POD section of a method or constructor.

Having `$int` appear multiple times in the example above might be confusing. Maybe the following more verbose format is better?

    $searcher->hits(
        query      => $query,       # Clownfish::Obj, required
        offset     => $offset,      # integer, default: 0
        num_wanted => $num_wanted,  # integer, default: 10
        sort_spec  => $sort_spec,   # Lucy::Search::SortSpec, default: undef
    );

Other things that could be improved:

- Type information for positional parameters.
- Type information for return types.
