### PR TITLE
Remove Bool to Num conversion methods

### DIFF
--- a/runtime/core/Clownfish/Boolean.c
+++ b/runtime/core/Clownfish/Boolean.c
@@ -53,16 +53,6 @@ Bool_Get_Value_IMP(Boolean *self) {
     return self->value;
 }
 
-double
-Bool_To_F64_IMP(Boolean *self) {
-    return (double)self->value;
-}
-
-int64_t
-Bool_To_I64_IMP(Boolean *self) {
-    return self->value;
-}
-
 Boolean*
 Bool_Clone_IMP(Boolean *self) {
     return self;

--- a/runtime/core/Clownfish/Boolean.c
+++ b/runtime/core/Clownfish/Boolean.c
@@ -63,11 +63,6 @@ Bool_To_I64_IMP(Boolean *self) {
     return self->value;
 }
 
-bool
-Bool_To_Bool_IMP(Boolean *self) {
-    return self->value;
-}
-
 Boolean*
 Bool_Clone_IMP(Boolean *self) {
     return self;

--- a/runtime/core/Clownfish/Boolean.cfh
+++ b/runtime/core/Clownfish/Boolean.cfh
@@ -53,9 +53,6 @@ public final class Clownfish::Boolean nickname Bool {
     public double
     To_F64(Boolean *self);
 
-    public bool
-    To_Bool(Boolean *self);
-
     /* Returns self. */
     public incremented Boolean*
     Clone(Boolean *self);

--- a/runtime/core/Clownfish/Boolean.cfh
+++ b/runtime/core/Clownfish/Boolean.cfh
@@ -47,12 +47,6 @@ public final class Clownfish::Boolean nickname Bool {
     public bool
     Get_Value(Boolean *self);
 
-    public int64_t
-    To_I64(Boolean *self);
-
-    public double
-    To_F64(Boolean *self);
-
     /* Returns self. */
     public incremented Boolean*
     Clone(Boolean *self);

--- a/runtime/core/Clownfish/Num.c
+++ b/runtime/core/Clownfish/Num.c
@@ -111,11 +111,6 @@ Float_To_I64_IMP(Float *self) {
     return (int64_t)self->value;
 }
 
-bool
-Float_To_Bool_IMP(Float *self) {
-    return self->value != 0.0;
-}
-
 String*
 Float_To_String_IMP(Float *self) {
     return Str_newf("%f64", self->value);
@@ -179,11 +174,6 @@ Int_Get_Value_IMP(Integer *self) {
 double
 Int_To_F64_IMP(Integer *self) {
     return (double)self->value;
-}
-
-bool
-Int_To_Bool_IMP(Integer *self) {
-    return self->value != 0;
 }
 
 String*

--- a/runtime/core/Clownfish/Num.cfh
+++ b/runtime/core/Clownfish/Num.cfh
@@ -40,12 +40,6 @@ public final class Clownfish::Float {
     public int64_t
     To_I64(Float *self);
 
-    /** Evaluate the number in a boolean context.  Returns true if it is
-     * non-zero.
-     */
-    public bool
-    To_Bool(Float *self);
-
     public incremented String*
     To_String(Float *self);
 
@@ -83,12 +77,6 @@ public final class Clownfish::Integer nickname Int {
 
     public double
     To_F64(Integer *self);
-
-    /** Evaluate the number in a boolean context.  Returns true if it is
-     * non-zero.
-     */
-    public bool
-    To_Bool(Integer *self);
 
     public incremented String*
     To_String(Integer *self);

--- a/runtime/core/Clownfish/Test/TestBoolean.c
+++ b/runtime/core/Clownfish/Test/TestBoolean.c
@@ -51,12 +51,6 @@ test_accessors(TestBatchRunner *runner) {
                 "Bool_Get_Value [true]");
     TEST_INT_EQ(runner, Bool_Get_Value(CFISH_FALSE), false,
                 "Bool_Get_Value [false]");
-    TEST_INT_EQ(runner, Bool_To_I64(CFISH_TRUE), 1, "Bool_To_I64 [true]");
-    TEST_INT_EQ(runner, Bool_To_I64(CFISH_FALSE), 0, "Bool_To_I64 [false]");
-    TEST_TRUE(runner, Bool_To_F64(CFISH_TRUE) == 1.0,
-              "Bool_To_F64 [true]");
-    TEST_TRUE(runner, Bool_To_F64(CFISH_FALSE) == 0.0,
-              "Bool_To_F64 [false]");
 }
 
 static void
@@ -81,7 +75,7 @@ test_Clone(TestBatchRunner *runner) {
 
 void
 TestBoolean_Run_IMP(TestBoolean *self, TestBatchRunner *runner) {
-    TestBatchRunner_Plan(runner, (TestBatch*)self, 14);
+    TestBatchRunner_Plan(runner, (TestBatch*)self, 10);
     test_To_String(runner);
     test_accessors(runner);
     test_Equals_and_Compare_To(runner);

--- a/runtime/go/clownfish/boolean_test.go
+++ b/runtime/go/clownfish/boolean_test.go
@@ -51,17 +51,6 @@ func TestBooleanToI64(t *testing.T) {
 	}
 }
 
-func TestBooleanToBool(t *testing.T) {
-	myTrue := NewBoolean(true)
-	myFalse := NewBoolean(false)
-	if !myTrue.ToBool() {
-		t.Errorf("Expected true, got false")
-	}
-	if myFalse.ToBool() {
-		t.Errorf("Expected false, got true")
-	}
-}
-
 func TestBooleanToString(t *testing.T) {
 	myTrue := NewBoolean(true)
 	myFalse := NewBoolean(false)

--- a/runtime/go/clownfish/boolean_test.go
+++ b/runtime/go/clownfish/boolean_test.go
@@ -29,28 +29,6 @@ func TestBooleanGetValue(t *testing.T) {
 	}
 }
 
-func TestBooleanToF64(t *testing.T) {
-	myTrue := NewBoolean(true)
-	myFalse := NewBoolean(false)
-	if got := myTrue.ToF64(); got != 1.0 {
-		t.Errorf("Expected 1.0, got %v", got)
-	}
-	if got := myFalse.ToF64(); got != 0.0 {
-		t.Errorf("Expected 0.0, got %v", got)
-	}
-}
-
-func TestBooleanToI64(t *testing.T) {
-	myTrue := NewBoolean(true)
-	myFalse := NewBoolean(false)
-	if got := myTrue.ToI64(); got != 1 {
-		t.Errorf("Expected 1, got %v", got)
-	}
-	if got := myFalse.ToI64(); got != 0 {
-		t.Errorf("Expected 0, got %v", got)
-	}
-}
-
 func TestBooleanToString(t *testing.T) {
 	myTrue := NewBoolean(true)
 	myFalse := NewBoolean(false)

--- a/runtime/go/clownfish/float_test.go
+++ b/runtime/go/clownfish/float_test.go
@@ -32,17 +32,6 @@ func TestFloatToI64(t *testing.T) {
 	}
 }
 
-func TestFloatToBool(t *testing.T) {
-	num := NewFloat(0.1)
-	if got := num.ToBool(); !got {
-		t.Errorf("Expected true, got %v", got)
-	}
-	zero := NewFloat(0)
-	if got := zero.ToBool(); got {
-		t.Errorf("Expected false, got %v", got)
-	}
-}
-
 func TestFloatToString(t *testing.T) {
 	num := NewFloat(2.5)
 	if got := num.ToString(); got != "2.5" {

--- a/runtime/go/clownfish/integer_test.go
+++ b/runtime/go/clownfish/integer_test.go
@@ -32,17 +32,6 @@ func TestIntToF64(t *testing.T) {
 	}
 }
 
-func TestIntToBool(t *testing.T) {
-	fortyTwo := NewInteger(42)
-	if got := fortyTwo.ToBool(); !got {
-		t.Errorf("Expected true, got %v", got)
-	}
-	zero := NewInteger(0)
-	if got := zero.ToBool(); got {
-		t.Errorf("Expected false, got %v", got)
-	}
-}
-
 func TestIntToString(t *testing.T) {
 	fortyTwo := NewInteger(42)
 	if got := fortyTwo.ToString(); got != "42" {

--- a/runtime/perl/t/binding/031-num.t
+++ b/runtime/perl/t/binding/031-num.t
@@ -17,7 +17,7 @@ use strict;
 use warnings;
 use lib 'buildlib';
 
-use Test::More tests => 28;
+use Test::More tests => 26;
 use Clownfish;
 use Clownfish::Boolean qw( $true_singleton $false_singleton );
 
@@ -27,7 +27,6 @@ isa_ok( $float, 'Clownfish::Float' );
 
 is ( $float->get_value, 0.5, 'Float get_value' );
 is ( $float->to_i64, 0, 'Float to_i64' );
-ok ( $float->to_bool, 'Float to_bool' );
 is ( $float->to_string, '0.5', 'Float to_string' );
 ok ( $float->equals($float), 'Float equals true' );
 ok ( !$float->equals($neg_float), 'Float equals false' );
@@ -42,7 +41,6 @@ my $neg_int = Clownfish::Integer->new(-12345);
 isa_ok( $int, 'Clownfish::Integer' );
 
 is ( $int->get_value, 12345, 'Integer get_value' );
-ok ( $int->to_bool, 'Integer to_bool' );
 is ( $int->to_string, '12345', 'Integer to_string' );
 ok ( $int->equals($int), 'Integer equals true' );
 ok ( !$int->equals($neg_int), 'Integer equals false' );

--- a/runtime/perl/t/binding/031-num.t
+++ b/runtime/perl/t/binding/031-num.t
@@ -17,7 +17,7 @@ use strict;
 use warnings;
 use lib 'buildlib';
 
-use Test::More tests => 26;
+use Test::More tests => 25;
 use Clownfish;
 use Clownfish::Boolean qw( $true_singleton $false_singleton );
 
@@ -55,7 +55,6 @@ isa_ok( $bool, 'Clownfish::Boolean' );
 
 ok ( $bool->get_value, 'Boolean get_value true' );
 ok ( !$false_singleton->get_value, 'Boolean get_value false' );
-is ( $bool->to_i64, 1, 'Boolean to_i64' );
 is ( $bool->to_string, 'true', 'Boolean to_string' );
 ok ( $bool->equals($true_singleton), 'Boolean equals true' );
 ok ( !$bool->equals($false_singleton), 'Boolean equals false' );


### PR DESCRIPTION
These methods used to be "virtual" methods defined in `Obj`. Now that they're non-virtual, there's no real use for them. Simply call `Get_Value` and convert the value manually.