### PR TITLE
CLOWNFISH-66 Python CFC core

### DIFF
--- a/compiler/python/clownfish/_cfc.c
+++ b/compiler/python/clownfish/_cfc.c
@@ -22,8 +22,10 @@ typedef struct {
     void *cfc_obj;
 } CFCPyWrapper;
 
+/***************************** CFCHierarchy *****************************/
+
 static CFCHierarchy*
-S_extract_hierarchy(PyObject *wrapper) {
+S_to_Hierarchy(PyObject *wrapper) {
     return (CFCHierarchy*)((CFCPyWrapper*)wrapper)->cfc_obj;
 }
 
@@ -55,10 +57,30 @@ S_CFCHierarchy_dealloc(CFCPyWrapper *wrapper) {
 }
 
 static PyObject*
+S_CFCHierarchy_build(PyObject *wrapper, PyObject *unused) {
+    CHY_UNUSED_VAR(unused);
+    CFCHierarchy_build(S_to_Hierarchy(wrapper));
+    Py_RETURN_NONE;
+}
+
+static PyObject*
 S_CFCHierarchy_add_include_dir(PyObject *wrapper, PyObject *dir) {
-    CFCHierarchy *wrapped  = S_extract_hierarchy(wrapper);
-    CFCHierarchy_add_include_dir(S_extract_hierarchy(wrapper),
+    CFCHierarchy_add_include_dir(S_to_Hierarchy(wrapper),
                                  PyUnicode_AsUTF8(dir));
+    Py_RETURN_NONE;
+}
+
+static PyObject*
+S_CFCHierarchy_add_source_dir(PyObject *wrapper, PyObject *dir) {
+    CFCHierarchy_add_source_dir(S_to_Hierarchy(wrapper),
+                                PyUnicode_AsUTF8(dir));
+    Py_RETURN_NONE;
+}
+
+static PyObject*
+S_CFCHierarchy_write_log(PyObject *wrapper, PyObject *unused) {
+    CHY_UNUSED_VAR(unused);
+    CFCHierarchy_write_log(S_to_Hierarchy(wrapper));
     Py_RETURN_NONE;
 }
 
@@ -79,8 +101,10 @@ static PyModuleDef cfc_model_module_def = {
 };
 
 static PyMethodDef hierarchy_methods[] = {
-    {"add_include_dir", (PyCFunction)S_CFCHierarchy_add_include_dir, METH_O,
-     NULL},
+    {"add_include_dir", (PyCFunction)S_CFCHierarchy_add_include_dir, METH_O,      NULL},
+    {"add_source_dir",  (PyCFunction)S_CFCHierarchy_add_source_dir,  METH_O,      NULL},
+    {"build",           (PyCFunction)S_CFCHierarchy_build,           METH_NOARGS, NULL},
+    {"write_log",       (PyCFunction)S_CFCHierarchy_write_log,       METH_NOARGS, NULL},
     {NULL}
 };
 

--- a/compiler/python/clownfish/cfc/__init__.py
+++ b/compiler/python/clownfish/cfc/__init__.py
@@ -13,5 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import clownfish._cfc
 from clownfish._cfc import *
+import site
+import os.path
+
+def _get_inc_dirs():
+    dirs = []
+    for path in site.getsitepackages():
+        path = os.path.join(path, "clownfish/_include")
+        dirs.append(path)
+    return dirs
+
+clownfish._cfc._get_inc_dirs = _get_inc_dirs
 

--- a/compiler/python/setup.py
+++ b/compiler/python/setup.py
@@ -37,8 +37,9 @@ compiler_type = distutils.ccompiler.get_default_compiler()
 # out of distutils, but the member variable has been in the same place for a
 # long time, so violating encapsulation may be ok.
 compiler_name = " ".join(compiler.compiler)
+make_command = "make" # TODO portability
 
-BASE_DIR = os.path.abspath(os.path.join(os.pardir, os.pardir, os.pardir))
+BASE_DIR        = os.path.abspath(os.path.join(os.pardir, os.pardir))
 PARENT_DIR      = os.path.abspath(os.pardir)
 CFC_SOURCE_DIR  = os.path.join(PARENT_DIR, 'src')
 CFC_INCLUDE_DIR = os.path.join(PARENT_DIR, 'include')
@@ -47,56 +48,20 @@ CHARMONIZER_C        = os.path.join(COMMON_SOURCE_DIR, 'charmonizer.c')
 CHARMONIZER_EXE_NAME = compiler.executable_filename('charmonizer')
 CHARMONIZER_EXE_PATH = os.path.join(os.curdir, CHARMONIZER_EXE_NAME)
 CHARMONY_H_PATH      = 'charmony.h'
-LEMON_DIR = os.path.join(BASE_DIR, 'lemon')
-LEMON_EXE_NAME = compiler.executable_filename('lemon')
-LEMON_EXE_PATH = os.path.join(LEMON_DIR, LEMON_EXE_NAME)
+LIBCFC_NAME          = 'libcfc.a' # TODO portability
+LIBCFC_PATH          = os.path.abspath(os.path.join(os.curdir, LIBCFC_NAME))
 
-# Accumulate lists of source files and target files.
-c_filepaths = []
-y_filepaths = []
+c_filepaths = [os.path.join('clownfish', '_cfc.c')]
 paths_to_clean = [
     CHARMONIZER_EXE_PATH,
     CHARMONY_H_PATH,
     '_charm*',
 ]
-c_filepaths.append(os.path.join('clownfish', '_cfc.c'))
-for (dirpath, dirnames, files) in os.walk(CFC_SOURCE_DIR):
-    for filename in files:
-        if filename.endswith('.y'):
-            path = os.path.join(dirpath, filename)
-            y_filepaths.append(path)
-            path = re.sub(r'y$', 'h', path)
-            paths_to_clean.append(path)
-            path = re.sub(r'h$', 'c', path)
-            paths_to_clean.append(path)
-            c_filepaths.append(path)
-            path = compiler.object_filenames([path])[0]
-            paths_to_clean.append(path)
-        if filename.endswith('.c'):
-            path = os.path.join(dirpath, filename)
-            c_filepaths.append(path)
-            path = compiler.object_filenames([path])[0]
-            paths_to_clean.append(path)
 
 def _quotify(text):
     text = text.replace('\\', '\\\\')
     text = text.replace('"', '\\"')
     return '"' + text + '"'
-
-def _run_make(command=[], directory=None):
-    current_directory = os.getcwd();
-    if (directory != None):
-        os.chdir(directory)
-    if (compiler_type == 'msvc'):
-        command.insert(0, 'Makefile.MSVC')
-        command.insert(0, '-f')
-    elif (platform.system() == 'Windows'):
-        command.insert(0, 'Makefile.MinGW')
-        command.insert(0, '-f')
-    command.insert(0, "make")
-    subprocess.check_call(command)
-    if (directory != None):
-        os.chdir(current_directory)
 
 class charmony(_Command):
     description = "Build and run charmonizer"
@@ -123,6 +88,8 @@ class charmony(_Command):
                 CHARMONIZER_EXE_PATH,
                 '--cc=' + _quotify(compiler_name),
                 '--enable-c',
+                '--host=python',
+                '--enable-makefile',
                 '--',
                 cflags
             ]
@@ -131,35 +98,26 @@ class charmony(_Command):
             print(" ".join(command))
             subprocess.check_call(command)
 
-class lemon(_Command):
-    description = "Compile the Lemon parser generator"
+class libcfc(_Command):
+    description = "Build CFC as a static archive."
     user_options = []
     def initialize_options(self):
         pass
     def finalize_options(self):
         pass
     def run(self):
-        if not os.path.exists(LEMON_EXE_PATH):
-            _run_make(['CC=' + _quotify(compiler_name)], directory=LEMON_DIR)
-
-class parsers(_Command):
-    description = "Run .y files through lemon"
-    user_options = []
-    def initialize_options(self):
-        pass
-    def finalize_options(self):
-        pass
-    def run(self):
-        for y_path in y_filepaths:
-            target = re.sub(r'y$', 'c', y_path)
-            if newer_group([y_path], target):
-                command = [LEMON_EXE_PATH, '-c', y_path]
-                subprocess.check_call(command)
+        self.run_command('charmony')
+        subprocess.check_call([make_command, '-j', 'static'])
+        # Touch Python binding file if the library has changed.
+        cfc_c = os.path.join('clownfish', '_cfc.c')
+        if newer_group(['libcfc.a'], cfc_c):
+            os.utime(cfc_c, None)
 
 class my_clean(_clean):
     def run(self):
         _clean.run(self)
-        _run_make(command=['clean'], directory=LEMON_DIR)
+        if os.path.isfile("Makefile"):
+            subprocess.check_call([make_command, 'distclean'])
         for elem in paths_to_clean:
             for path in glob.glob(elem):
                 print("removing " + path)
@@ -171,8 +129,7 @@ class my_clean(_clean):
 class my_build(_build):
     def run(self):
         self.run_command('charmony')
-        self.run_command('lemon')
-        self.run_command('parsers')
+        self.run_command('libcfc')
         _build.run(self)
 
 cfc_extension = Extension('clownfish._cfc',
@@ -182,6 +139,7 @@ cfc_extension = Extension('clownfish._cfc',
                               CFC_SOURCE_DIR,
                               os.curdir,
                           ],
+                          extra_link_args = [LIBCFC_PATH],
                           sources = c_filepaths)
 
 setup(name = 'clownfish-cfc',
@@ -195,9 +153,8 @@ setup(name = 'clownfish-cfc',
       cmdclass = {
           'build': my_build,
           'clean': my_clean,
-          'lemon': lemon,
           'charmony': charmony,
-          'parsers': parsers,
+          'libcfc': libcfc,
       },
       ext_modules = [cfc_extension])
 

--- a/compiler/python/setup.py
+++ b/compiler/python/setup.py
@@ -26,6 +26,8 @@ import re
 import shutil
 import subprocess
 import sysconfig
+import sys
+import unittest
 
 # Get a compiler object and and strings representing the compiler type and
 # CFLAGS.
@@ -132,6 +134,33 @@ class my_build(_build):
         self.run_command('libcfc')
         _build.run(self)
 
+class test(_Command):
+    description = "Run unit tests."
+    user_options = []
+    def initialize_options(self):
+        pass
+    def finalize_options(self):
+        pass
+    def ext_build_dir(self):
+        """Returns the build directory for compiled extensions"""
+        pattern = "lib.{platform}-{version[0]}.{version[1]}"
+        dirname = pattern.format(platform=sysconfig.get_platform(),
+                                 version=sys.version_info)
+        return os.path.join('build', dirname)
+
+    def run(self):
+        self.run_command('build')
+        orig_sys_path = sys.path[:]
+        sys.path.append(self.ext_build_dir())
+
+        loader = unittest.TestLoader()
+        tests = loader.discover("test")
+        test_runner = unittest.runner.TextTestRunner()
+        test_runner.run(tests)
+
+        # restore sys.path
+        sys.path = orig_sys_path
+
 cfc_extension = Extension('clownfish._cfc',
                           define_macros = [('CFCPYTHON', None)],
                           include_dirs = [
@@ -155,6 +184,7 @@ setup(name = 'clownfish-cfc',
           'clean': my_clean,
           'charmony': charmony,
           'libcfc': libcfc,
+          'test': test,
       },
       ext_modules = [cfc_extension])
 

--- a/compiler/python/test/test_cfc.py
+++ b/compiler/python/test/test_cfc.py
@@ -1,0 +1,12 @@
+import unittest
+import clownfish.cfc
+
+class MyTest(unittest.TestCase):
+
+    def testTrue(self):
+        self.assertTrue(True, "True should be true")
+
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
Improve basic CFC Python bindings.

*   Migrate to Charmonizer-generated Makefile build.
*   Add a "test" target to setup.py.
*   Add bindings for a few more parts of the CFC core.