### PR TITLE
CLOWNFISH-66 Py glue part 2

### DIFF
--- a/compiler/include/CFC.h
+++ b/compiler/include/CFC.h
@@ -58,6 +58,8 @@
 #include "CFCPerlTypeMap.h"
 
 #include "CFCPython.h"
+#include "CFCPyClass.h"
+#include "CFCPyMethod.h"
 
 #include "CFCRuby.h"
 

--- a/compiler/src/CFCPyClass.c
+++ b/compiler/src/CFCPyClass.c
@@ -15,6 +15,7 @@
  */
 
 #include <string.h>
+#include <ctype.h>
 #include <stdlib.h>
 
 #define CFC_NEED_BASE_STRUCT_DEF 1
@@ -43,6 +44,9 @@ static size_t registry_cap  = 0;
 
 static void
 S_CFCPyClass_destroy(CFCPyClass *self);
+
+static char*
+S_pytype_struct_def(CFCPyClass *self);
 
 static const CFCMeta CFCPERLCLASS_META = {
     "Clownfish::CFC::Binding::Python::Class",
@@ -134,5 +138,93 @@ CFCPyClass_clear_registry(void) {
 
 char*
 CFCPyClass_gen_binding_code(CFCPyClass *self) {
-    return CFCUtil_strdup("");
+    if (!self->client) {
+        CFCUtil_die("No Clownfish class defined for %s", self->class_name);
+    }
+    CFCClass *klass = self->client;
+    char *bindings  = CFCUtil_strdup(self->pre_code ? self->pre_code : "");
+    char *meth_defs = CFCUtil_strdup(self->meth_defs);
+
+    // Complete the PyMethodDef array.
+    const char *struct_sym = CFCClass_get_struct_sym(klass);
+    char *meth_defs_pattern =
+        "static PyMethodDef %s_pymethods[] = {\n"
+        "%s"
+        "   {NULL}\n"
+        "};\n"
+        ;
+    char *meth_defs_array = CFCUtil_sprintf(meth_defs_pattern, struct_sym,
+                                            meth_defs);
+    bindings = CFCUtil_cat(bindings, meth_defs_array, NULL);
+    FREEMEM(meth_defs_array);
+    FREEMEM(meth_defs);
+
+    // PyTypeObject struct def.
+    char *struct_def = S_pytype_struct_def(self);
+    bindings = CFCUtil_cat(bindings, struct_def, NULL);
+    FREEMEM(struct_def);
+
+    return bindings;
 }
+
+static char*
+S_pytype_struct_def(CFCPyClass *self) {
+    CFCClass *klass = self->client;
+    const char *parcel_name = CFCParcel_get_name(self->parcel);
+    char *pymod_name = CFCUtil_strdup(parcel_name);
+    // TODO: Stop lowercasing when parcels are restricted to lowercase.
+    for (int i = 0; pymod_name[i] != '\0'; i++) {
+        pymod_name[i] = tolower(pymod_name[i]);
+    }
+
+    const char *struct_sym = CFCClass_get_struct_sym(klass);
+
+    char pattern[] =
+        "static PyTypeObject %s_pytype_struct = {\n"
+        "    PyVarObject_HEAD_INIT(NULL, 0)\n"
+        "    \"%s.%s\", // tp_name\n"
+        "    0,                                  // tp_basicsize THIS IS A LIE!\n"
+        "    0,                                  // tp_itemsize\n"
+        "    0,                                  // tp_dealloc\n"
+        "    0,                                  // tp_print\n"
+        "    0,                                  // tp_getattr\n"
+        "    0,                                  // tp_setattr\n"
+        "    0,                                  // tp_reserved\n"
+        "    0,                                  // tp_repr\n"
+        "    0,                                  // tp_as_number\n"
+        "    0,                                  // tp_as_sequence\n"
+        "    0,                                  // tp_as_mapping\n"
+        "    0,                                  // tp_hash\n"
+        "    0,                                  // tp_call\n"
+        "    0,                                  // tp_str\n"
+        "    0,                                  // tp_getattro\n"
+        "    0,                                  // tp_setattro\n"
+        "    0,                                  // tp_as_buffer\n"
+        "    Py_TPFLAGS_DEFAULT,                 // tp_flags\n"
+        "    0,                                  // tp_doc\n"
+        "    0,                                  // tp_traverse\n"
+        "    0,                                  // tp_clear\n"
+        "    0,                                  // tp_richcompare\n"
+        "    0,                                  // tp_weaklistoffset\n"
+        "    0,                                  // tp_iter\n"
+        "    0,                                  // tp_iternext\n"
+        "    %s_pymethods,                       // tp_methods\n"
+        "    0,                                  // tp_members\n"
+        "    0,                                  // tp_getset\n"
+        "    0,                                  // tp_base\n"
+        "    0,                                  // tp_dict\n"
+        "    0,                                  // tp_descr_get\n"
+        "    0,                                  // tp_descr_set\n"
+        "    0,                                  // tp_dictoffset\n"
+        "    0,                                  // tp_init\n"
+        "    0,                                  // tp_allow\n"
+        "    0,                                  // tp_new\n"
+        "};\n"
+        ;
+    char *content = CFCUtil_sprintf(pattern, struct_sym, pymod_name,
+                                    struct_sym, struct_sym);
+
+    FREEMEM(pymod_name);
+    return content;
+}
+

--- a/compiler/src/CFCPyClass.c
+++ b/compiler/src/CFCPyClass.c
@@ -1,0 +1,68 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define CFC_NEED_BASE_STRUCT_DEF 1
+
+#include "CFCBase.h"
+#include "CFCPyClass.h"
+#include "CFCPyMethod.h"
+#include "CFCParcel.h"
+#include "CFCUtil.h"
+#include "CFCClass.h"
+#include "CFCFunction.h"
+#include "CFCMethod.h"
+
+struct CFCPyClass {
+    CFCBase base;
+    CFCParcel *parcel;
+    char *class_name;
+    CFCClass *client;
+    char *pre_code;
+    char *meth_defs;
+};
+
+static void
+S_CFCPyClass_destroy(CFCPyClass *self);
+
+static const CFCMeta CFCPERLCLASS_META = {
+    "Clownfish::CFC::Binding::Python::Class",
+    sizeof(CFCPyClass),
+    (CFCBase_destroy_t)S_CFCPyClass_destroy
+};
+
+CFCPyClass*
+CFCPyClass_new(CFCClass *client) {
+    CFCUTIL_NULL_CHECK(client);
+    CFCPyClass *self = (CFCPyClass*)CFCBase_allocate(&CFCPERLCLASS_META);
+    CFCParcel *parcel = CFCClass_get_parcel(client);
+    self->parcel = (CFCParcel*)CFCBase_incref((CFCBase*)parcel);
+    self->class_name = CFCUtil_strdup(CFCClass_get_name(client));
+    self->client = (CFCClass*)CFCBase_incref((CFCBase*)client);
+    self->pre_code = NULL;
+    self->meth_defs = CFCUtil_strdup("");
+    return self;
+}
+
+static void
+S_CFCPyClass_destroy(CFCPyClass *self) {
+    CFCBase_decref((CFCBase*)self->parcel);
+    CFCBase_decref((CFCBase*)self->client);
+    FREEMEM(self->class_name);
+    FREEMEM(self->pre_code);
+    FREEMEM(self->meth_defs);
+    CFCBase_destroy((CFCBase*)self);
+}
+

--- a/compiler/src/CFCPyClass.h
+++ b/compiler/src/CFCPyClass.h
@@ -32,6 +32,30 @@ struct CFCClass;
 CFCPyClass*
 CFCPyClass_new(struct CFCClass *client);
 
+/** Add a new class binding to the registry.  Each unique parcel/class-name
+  * combination may only be registered once.
+  */
+void
+CFCPyClass_add_to_registry(CFCPyClass *self);
+
+/** Given a class name, return a class binding if one exists.
+  */
+CFCPyClass*
+CFCPyClass_singleton(const char *class_name);
+
+/** All registered class bindings.
+  */
+CFCPyClass**
+CFCPyClass_registry();
+
+/** Release all memory and references held by the registry.
+  */
+void
+CFCPyClass_clear_registry(void);
+
+char*
+CFCPyClass_gen_binding_code(CFCPyClass *self);
+
 #ifdef __cplusplus
 }
 #endif

--- a/compiler/src/CFCPyClass.h
+++ b/compiler/src/CFCPyClass.h
@@ -1,0 +1,40 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef H_CFCPYCLASS
+#define H_CFCPYCLASS
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct CFCPyClass CFCPyClass;
+struct CFCParcel;
+struct CFCClass;
+
+/** Clownfish::CFC::Binding::Python::Class - Generate Python binding code for a
+ * Clownfish::CFC::Model::Class.
+ */
+
+CFCPyClass*
+CFCPyClass_new(struct CFCClass *client);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* H_CFCPYCLASS */
+

--- a/compiler/src/CFCPython.c
+++ b/compiler/src/CFCPython.c
@@ -39,7 +39,7 @@ struct CFCPython {
     char *footer;
 };
 
-void
+static void
 S_destroy(CFCPython *self);
 
 static const CFCMeta CFCPYTHON_META = {
@@ -58,7 +58,7 @@ CFCPython_new(CFCHierarchy *hierarchy) {
     return self;
 }
 
-void
+static void
 S_destroy(CFCPython *self) {
     CFCBase_decref((CFCBase*)self->hierarchy);
     FREEMEM(self->header);

--- a/compiler/src/CFCPython.c
+++ b/compiler/src/CFCPython.c
@@ -398,7 +398,7 @@ S_gen_type_linkups(CFCPython *self, CFCParcel *parcel, CFCClass **ordered) {
         "    PyTypeObject **py_types = (PyTypeObject**)CFISH_MALLOCATE(py_types_size);\n"
         "%s\n"
         "%s\n"
-        "    //CFBind_assoc_py_types(handles, py_types, num_items);\n"
+        "    CFBind_assoc_py_types(handles, py_types, num_items);\n"
         "    CFISH_FREEMEM(handles);\n"
         "    CFISH_FREEMEM(py_types);\n"
         "}\n"

--- a/compiler/src/CFCPython.c
+++ b/compiler/src/CFCPython.c
@@ -491,6 +491,7 @@ S_write_module_file(CFCPython *self, CFCParcel *parcel, const char *dest) {
         "\n"
         "PyMODINIT_FUNC\n"
         "PyInit__%s(void) {\n"
+        "    cfish_Class_bootstrap_hook1 = CFBind_class_bootstrap_hook1;\n"
         "    S_link_py_types();\n"
         "    PyObject *module = PyModule_Create(&module_def);\n"
         "    return module;\n"

--- a/runtime/core/Clownfish/Class.c
+++ b/runtime/core/Clownfish/Class.c
@@ -54,6 +54,7 @@ static int32_t
 S_claim_parcel_id(void);
 
 static LockFreeRegistry *Class_registry;
+cfish_Class_bootstrap_hook1_t cfish_Class_bootstrap_hook1;
 
 void
 Class_bootstrap(const cfish_ClassSpec *specs, size_t num_specs,
@@ -145,6 +146,9 @@ Class_bootstrap(const cfish_ClassSpec *specs, size_t num_specs,
         }
         else {
             klass->obj_alloc_size = ivars_offset + spec->ivars_size;
+        }
+        if (cfish_Class_bootstrap_hook1 != NULL) {
+            cfish_Class_bootstrap_hook1(klass);
         }
 
         klass->flags = 0;

--- a/runtime/core/Clownfish/Class.cfh
+++ b/runtime/core/Clownfish/Class.cfh
@@ -32,6 +32,7 @@ public final class Clownfish::Class inherits Clownfish::Obj {
     int32_t             parcel_id;
     uint32_t            obj_alloc_size;
     uint32_t            class_alloc_size;
+    void               *host_type;
     Method            **methods;
     cfish_method_t[1]   vtable; /* flexible array */
 

--- a/runtime/core/Clownfish/Class.cfh
+++ b/runtime/core/Clownfish/Class.cfh
@@ -149,5 +149,13 @@ __C__
 #define CFISH_ALLOCA_OBJ(class) \
     cfish_alloca(CFISH_Class_Get_Obj_Alloc_Size(class))
 
+/** Bootstrapping hook/hack needed by the Python bindings.
+ *
+ * TODO: Refactor this away in favor of a more general solution.
+ */
+typedef void
+(*cfish_Class_bootstrap_hook1_t)(cfish_Class *self);
+extern cfish_Class_bootstrap_hook1_t cfish_Class_bootstrap_hook1;
+
 __END_C__
 

--- a/runtime/core/Clownfish/Method.c
+++ b/runtime/core/Clownfish/Method.c
@@ -21,6 +21,7 @@
 #include "Clownfish/String.h"
 #include "Clownfish/Err.h"
 #include "Clownfish/Class.h"
+#include "Clownfish/CharBuf.h"
 
 Method*
 Method_new(String *name, cfish_method_t callback_func, uint32_t offset) {
@@ -81,4 +82,29 @@ Method_Is_Excluded_From_Host_IMP(Method *self) {
     return self->is_excluded;
 }
 
+String*
+Method_lower_snake_alias(cfish_Method *method) {
+    cfish_String *host_alias = CFISH_Method_Get_Host_Alias(method);
+    if (host_alias) {
+        return (cfish_String*)CFISH_INCREF(host_alias);
+    }
 
+    // Convert to lowercase.
+    cfish_String *name = CFISH_Method_Get_Name(method);
+    cfish_CharBuf *buf = cfish_CB_new(CFISH_Str_Get_Size(name));
+    cfish_StringIterator *iter = CFISH_Str_Top(name);
+    int32_t code_point;
+    while (CFISH_STR_OOB != (code_point = CFISH_StrIter_Next(iter))) {
+        if (code_point > 127) {
+            THROW(CFISH_ERR, "Can't lowercase '%o'", name);
+        }
+        else {
+            CFISH_CB_Cat_Char(buf, tolower(code_point));
+        }
+    }
+    cfish_String *retval = CFISH_CB_Yield_String(buf);
+    CFISH_DECREF(iter);
+    CFISH_DECREF(buf);
+
+    return retval;
+}

--- a/runtime/core/Clownfish/Method.cfh
+++ b/runtime/core/Clownfish/Method.cfh
@@ -53,6 +53,12 @@ final class Clownfish::Method inherits Clownfish::Obj {
 
     public void
     Destroy(Method *self);
+
+    /** Return either a specified host alias or a lower-snake-case version of
+      * the method name.
+      */
+    inert incremented String*
+    lower_snake_alias(Method *method);
 }
 
 

--- a/runtime/perl/xs/XSBind.c
+++ b/runtime/perl/xs/XSBind.c
@@ -710,29 +710,7 @@ cfish_Class_find_parent_class(cfish_String *class_name) {
 
 cfish_String*
 CFISH_Method_Host_Name_IMP(cfish_Method *self) {
-    cfish_String *host_alias = CFISH_Method_Get_Host_Alias(self);
-    if (host_alias) {
-        return (cfish_String*)CFISH_INCREF(host_alias);
-    }
-
-    // Convert to lowercase.
-    cfish_String *name = CFISH_Method_Get_Name(self);
-    cfish_CharBuf *buf = cfish_CB_new(CFISH_Str_Get_Size(name));
-    cfish_StringIterator *iter = CFISH_Str_Top(name);
-    int32_t code_point;
-    while (CFISH_STR_OOB != (code_point = CFISH_StrIter_Next(iter))) {
-        if (code_point > 127) {
-            THROW(CFISH_ERR, "Can't lowercase '%o'", name);
-        }
-        else {
-            CFISH_CB_Cat_Char(buf, tolower(code_point));
-        }
-    }
-    cfish_String *retval = CFISH_CB_Yield_String(buf);
-    CFISH_DECREF(iter);
-    CFISH_DECREF(buf);
-
-    return retval;
+    return cfish_Method_lower_snake_alias(self);
 }
 
 /***************************** Clownfish::Err *******************************/

--- a/runtime/python/cfext/CFBind.c
+++ b/runtime/python/cfext/CFBind.c
@@ -938,9 +938,7 @@ cfish_Class_find_parent_class(cfish_String *class_name) {
 
 cfish_String*
 CFISH_Method_Host_Name_IMP(cfish_Method *self) {
-    CFISH_UNUSED_VAR(self);
-    CFISH_THROW(CFISH_ERR, "TODO");
-    CFISH_UNREACHABLE_RETURN(cfish_String*);
+    return cfish_Method_lower_snake_alias(self);
 }
 
 /**** Err ******************************************************************/

--- a/runtime/python/cfext/CFBind.c
+++ b/runtime/python/cfext/CFBind.c
@@ -912,23 +912,26 @@ CFISH_Class_Init_Obj_IMP(cfish_Class *self, void *allocation) {
 
 void
 cfish_Class_register_with_host(cfish_Class *singleton, cfish_Class *parent) {
+    // FIXME
     CFISH_UNUSED_VAR(singleton);
     CFISH_UNUSED_VAR(parent);
-    CFISH_THROW(CFISH_ERR, "TODO");
 }
 
 cfish_Vector*
 cfish_Class_fresh_host_methods(cfish_String *class_name) {
+    // FIXME Scan Python class for host methods which override.  Until this is
+    // implemented, it will be impossible to override Clownfish methods from
+    // Python.
     CFISH_UNUSED_VAR(class_name);
-    CFISH_THROW(CFISH_ERR, "TODO");
-    CFISH_UNREACHABLE_RETURN(cfish_Vector*);
+    return cfish_Vec_new(0);
 }
 
 cfish_String*
 cfish_Class_find_parent_class(cfish_String *class_name) {
+    // FIXME Until this is implemented, subclassing from Python will be
+    // impossible.
     CFISH_UNUSED_VAR(class_name);
-    CFISH_THROW(CFISH_ERR, "TODO");
-    CFISH_UNREACHABLE_RETURN(cfish_String*);
+    return NULL;
 }
 
 /**** Method ***************************************************************/

--- a/runtime/python/cfext/CFBind.c
+++ b/runtime/python/cfext/CFBind.c
@@ -930,17 +930,28 @@ S_get_cached_py_type(cfish_Class *self) {
 
 cfish_Obj*
 CFISH_Class_Make_Obj_IMP(cfish_Class *self) {
-    CFISH_UNUSED_VAR(self);
-    CFISH_THROW(CFISH_ERR, "TODO");
-    CFISH_UNREACHABLE_RETURN(cfish_Obj*);
+    PyTypeObject *py_type = S_get_cached_py_type(self);
+    cfish_Obj *obj = (cfish_Obj*)py_type->tp_alloc(py_type, 0);
+    obj->klass = self;
+    return obj;
 }
 
 cfish_Obj*
 CFISH_Class_Init_Obj_IMP(cfish_Class *self, void *allocation) {
-    CFISH_UNUSED_VAR(self);
-    CFISH_UNUSED_VAR(allocation);
-    CFISH_THROW(CFISH_ERR, "TODO");
-    CFISH_UNREACHABLE_RETURN(cfish_Obj*);
+    PyTypeObject *py_type = S_get_cached_py_type(self);
+    // It would be nice if we could call PyObject_Init() here and feel
+    // confident that we have performed all Python-specific initialization
+    // under all possible configurations, but that's not possible.  In
+    // addition to setting ob_refcnt and ob_type, PyObject_Init() performs
+    // tracking for heap allocated objects under special builds -- but
+    // Class_Init_Obj() may be called on non-heap memory, such as
+    // stack-allocated Clownfish Strings.  Therefore, we must perform a subset
+    // of tasks selected from PyObject_Init() manually.
+    cfish_Obj *obj = (cfish_Obj*)allocation;
+    obj->ob_base.ob_refcnt = 1;
+    obj->ob_base.ob_type = py_type;
+    obj->klass = self;
+    return obj;
 }
 
 void

--- a/runtime/python/cfext/CFBind.h
+++ b/runtime/python/cfext/CFBind.h
@@ -219,6 +219,9 @@ CFBind_maybe_convert_float(PyObject *input, float *ptr);
 int
 CFBind_maybe_convert_double(PyObject *input, double *ptr);
 
+void
+CFBind_class_bootstrap_hook1(struct cfish_Class *self);
+
 #ifdef __cplusplus
 }
 #endif

--- a/runtime/python/cfext/CFBind.h
+++ b/runtime/python/cfext/CFBind.h
@@ -112,6 +112,13 @@ cfish_Obj*
 CFBind_py_to_cfish_noinc(PyObject *py_obj, cfish_Class *klass,
                          void *allocation);
 
+/** Associate Clownfish classes with Python type objects.  (Internal-only,
+  * used during bootstrapping.)
+  */
+void
+CFBind_assoc_py_types(struct cfish_Class ***klass_handles,
+                      PyTypeObject **py_types, int32_t num_items);
+
 typedef struct CFBindArg {
     cfish_Class *klass;
     void        *ptr;

--- a/runtime/python/test/test_clownfish.py
+++ b/runtime/python/test/test_clownfish.py
@@ -21,6 +21,8 @@ class MyTest(unittest.TestCase):
     def testTrue(self):
         self.assertTrue(True, "True should be true")
 
+    def testClassesPresent(self):
+        self.assertIsInstance(clownfish.Hash, type)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Make PyTypeObjects and Clownfish Classes work together.

* Generate PyTypeObject def for each Clownfish class.
* Object allocation and initialization for Py glue.
* Make Clownfish classes aware of their corresponding PyTypeObjects.
* Bootstrap Clownfish parcels and Classes, Python type objects and modules.
