### PR TITLE
CLOWNFISH-66 Py glue part 3

### DIFF
--- a/compiler/src/CFCPyClass.c
+++ b/compiler/src/CFCPyClass.c
@@ -145,6 +145,23 @@ CFCPyClass_gen_binding_code(CFCPyClass *self) {
     char *bindings  = CFCUtil_strdup(self->pre_code ? self->pre_code : "");
     char *meth_defs = CFCUtil_strdup(self->meth_defs);
 
+    // Instance methods.
+    CFCMethod **methods = CFCClass_fresh_methods(klass);
+    for (size_t j = 0; methods[j] != NULL; j++) {
+        CFCMethod *meth = methods[j];
+
+        if (CFCMethod_excluded_from_host(meth)
+            || !CFCMethod_can_be_bound(meth)
+           ) {
+            continue;
+        }
+
+        // Add the function wrapper.
+        char *wrapper = CFCPyMethod_wrapper(meth, klass);
+        bindings = CFCUtil_cat(bindings, wrapper, "\n", NULL);
+        FREEMEM(wrapper);
+    }
+
     // Complete the PyMethodDef array.
     const char *struct_sym = CFCClass_get_struct_sym(klass);
     char *meth_defs_pattern =

--- a/compiler/src/CFCPyClass.c
+++ b/compiler/src/CFCPyClass.c
@@ -145,6 +145,14 @@ CFCPyClass_gen_binding_code(CFCPyClass *self) {
     char *bindings  = CFCUtil_strdup(self->pre_code ? self->pre_code : "");
     char *meth_defs = CFCUtil_strdup(self->meth_defs);
 
+    // Constructor.
+    CFCFunction *init_func = CFCClass_function(klass, "init");
+    if (init_func && CFCFunction_can_be_bound(init_func)) {
+        char *wrapper = CFCPyMethod_constructor_wrapper(init_func, klass);
+        bindings = CFCUtil_cat(bindings, wrapper, "\n", NULL);
+        FREEMEM(wrapper);
+    }
+
     // Instance methods.
     CFCMethod **methods = CFCClass_fresh_methods(klass);
     for (size_t j = 0; methods[j] != NULL; j++) {
@@ -201,6 +209,16 @@ S_pytype_struct_def(CFCPyClass *self) {
 
     const char *struct_sym = CFCClass_get_struct_sym(klass);
 
+    char *tp_new;
+    CFCFunction *init_func = CFCClass_function(klass, "init");
+    if (init_func && CFCFunction_can_be_bound(init_func)) {
+        tp_new = CFCUtil_sprintf("S_%s_PY_NEW",
+                                 CFCClass_full_struct_sym(klass));
+    }
+    else {
+        tp_new = CFCUtil_strdup("0");
+    }
+
     char pattern[] =
         "static PyTypeObject %s_pytype_struct = {\n"
         "    PyVarObject_HEAD_INIT(NULL, 0)\n"
@@ -240,12 +258,13 @@ S_pytype_struct_def(CFCPyClass *self) {
         "    0,                                  // tp_dictoffset\n"
         "    0,                                  // tp_init\n"
         "    0,                                  // tp_allow\n"
-        "    0,                                  // tp_new\n"
+        "    %s,                                 // tp_new\n"
         "};\n"
         ;
     char *content = CFCUtil_sprintf(pattern, struct_sym, pymod_name,
-                                    struct_sym, struct_sym);
+                                    struct_sym, struct_sym, tp_new);
 
+    FREEMEM(tp_new);
     FREEMEM(pymod_name);
     return content;
 }

--- a/compiler/src/CFCPyClass.c
+++ b/compiler/src/CFCPyClass.c
@@ -160,6 +160,11 @@ CFCPyClass_gen_binding_code(CFCPyClass *self) {
         char *wrapper = CFCPyMethod_wrapper(meth, klass);
         bindings = CFCUtil_cat(bindings, wrapper, "\n", NULL);
         FREEMEM(wrapper);
+
+        // Add PyMethodDef entry.
+        char *meth_def = CFCPyMethod_pymethoddef(meth, klass);
+        meth_defs = CFCUtil_cat(meth_defs, "    ", meth_def, "\n", NULL);
+        FREEMEM(meth_def);
     }
 
     // Complete the PyMethodDef array.

--- a/compiler/src/CFCPyMethod.c
+++ b/compiler/src/CFCPyMethod.c
@@ -81,6 +81,58 @@ S_gen_decs(CFCParamList *param_list, int first_tick) {
     return decs;
 }
 
+/* Some of the ParseTuple conversion routines provided by the Python-flavored
+ * CFBind module accept a CFBindArg instead of just a pointer to the value
+ * itself.  This routine generates the declarations for those CFBindArg
+ * variables, as well as handling some default values.
+ */
+static char*
+S_gen_declaration(CFCVariable *var, const char *val) {
+    CFCType *type = CFCVariable_get_type(var);
+    const char *var_name = CFCVariable_get_name(var);
+    const char *type_str = CFCType_to_c(type);
+    char *result = NULL;
+
+    if (CFCType_is_object(type)) {
+        const char *specifier = CFCType_get_specifier(type);
+        if (strcmp(specifier, "cfish_String") == 0) {
+            if (val && strcmp(val, "NULL") != 0) {
+                const char pattern[] =
+                    "    const char arg_%s_DEFAULT[] = %s;\n"
+                    "    %s_ARG = CFISH_SSTR_WRAP_UTF8(\n"
+                    "        arg_%s_DEFAULT, sizeof(arg_%s_DEFAULT) - 1);\n"
+                    ;
+                result = CFCUtil_sprintf(pattern, var_name, val, var_name,
+                                         var_name, var_name);
+            }
+        }
+        else {
+            if (val && strcmp(val, "NULL") != 0) {
+                CFCUtil_die("Can't assign a default of '%s' to a %s",
+                            val, type_str);
+            }
+            if (strcmp(specifier, "cfish_Hash") != 0
+                && strcmp(specifier, "cfish_Vector") != 0
+                ) {
+                const char *class_var = CFCType_get_class_var(type);
+                char pattern[] =
+                    "    CFBindArg wrap_arg_%s = {%s, &%s_ARG};\n"
+                    ;
+                result = CFCUtil_sprintf(pattern, var_name, class_var,
+                                         var_name);
+            }
+        }
+    }
+    else if (CFCType_is_primitive(type)) {
+        ;
+    }
+    else {
+        CFCUtil_die("Unexpected type, can't gen declaration: %s", type_str);
+    }
+
+    return result;
+}
+
 /* Generate the code which parses arguments passed from Python and converts
  * them to Clownfish-flavored C values.
  */
@@ -99,7 +151,9 @@ S_gen_arg_parsing(CFCParamList *param_list, int first_tick, char **error) {
     int optional_started = 0;
 
     for (int i = first_tick; i < num_vars; i++) {
+        CFCVariable *var  = vars[i];
         const char  *val  = vals[i];
+
         if (val == NULL) {
             if (optional_started) { // problem!
                 *error = "Required after optional param";
@@ -111,6 +165,10 @@ S_gen_arg_parsing(CFCParamList *param_list, int first_tick, char **error) {
                 optional_started = 1;
             }
         }
+
+        char *declaration = S_gen_declaration(var, val);
+        declarations = CFCUtil_cat(declarations, declaration, NULL);
+        FREEMEM(declaration);
     }
 
     char parse_pattern[] =

--- a/compiler/src/CFCPyMethod.c
+++ b/compiler/src/CFCPyMethod.c
@@ -201,6 +201,10 @@ S_gen_arg_parsing(CFCParamList *param_list, int first_tick, char **error) {
         CFCVariable *var  = vars[i];
         const char  *val  = vals[i];
 
+        const char *var_name = CFCVariable_get_name(var);
+        keywords = CFCUtil_cat(keywords, "\"", var_name, "\", ", NULL);
+
+        // Build up ParseTuple format string.
         if (val == NULL) {
             if (optional_started) { // problem!
                 *error = "Required after optional param";
@@ -210,8 +214,10 @@ S_gen_arg_parsing(CFCParamList *param_list, int first_tick, char **error) {
         else {
             if (!optional_started) {
                 optional_started = 1;
+                format_str = CFCUtil_cat(format_str, "|", NULL);
             }
         }
+        format_str = CFCUtil_cat(format_str, "O&", NULL);
 
         char *declaration = S_gen_declaration(var, val);
         declarations = CFCUtil_cat(declarations, declaration, NULL);

--- a/compiler/src/CFCPyMethod.c
+++ b/compiler/src/CFCPyMethod.c
@@ -464,7 +464,8 @@ S_gen_decrefs(CFCParamList *param_list, int first_tick) {
         const char *micro_sym = CFCVariable_get_name(var);
         const char *specifier = CFCType_get_specifier(type);
 
-        if (strcmp(specifier, "cfish_String") == 0
+        if (strcmp(specifier, "cfish_Obj") == 0
+             || strcmp(specifier, "cfish_String") == 0
              || strcmp(specifier, "cfish_Vector") == 0
              || strcmp(specifier, "cfish_Hash") == 0
             ) {

--- a/compiler/src/CFCPyMethod.c
+++ b/compiler/src/CFCPyMethod.c
@@ -519,3 +519,24 @@ CFCPyMethod_wrapper(CFCMethod *method, CFCClass *invoker) {
     return wrapper;
 }
 
+char*
+CFCPyMethod_pymethoddef(CFCMethod *method, CFCClass *invoker) {
+    CFCParamList *param_list = CFCMethod_get_param_list(method);
+    const char *flags = CFCParamList_num_vars(param_list) == 1
+                        ? "METH_NOARGS"
+                        : "METH_KEYWORDS|METH_VARARGS";
+    char *meth_sym = CFCMethod_full_method_sym(method, invoker);
+    char *micro_sym = CFCUtil_strdup(CFCSymbol_get_name((CFCSymbol*)method));
+    for (int i = 0; micro_sym[i] != 0; i++) {
+        micro_sym[i] = tolower(micro_sym[i]);
+    }
+
+    char pattern[] =
+        "{\"%s\", (PyCFunction)S_%s, %s, NULL},";
+    char *py_meth_def = CFCUtil_sprintf(pattern, micro_sym, meth_sym, flags);
+
+    FREEMEM(meth_sym);
+    FREEMEM(micro_sym);
+    return py_meth_def;
+}
+

--- a/compiler/src/CFCPyMethod.c
+++ b/compiler/src/CFCPyMethod.c
@@ -71,7 +71,7 @@ S_build_py_args(CFCParamList *param_list) {
  * them to Clownfish-flavored C values.
  */
 static char*
-S_gen_arg_parsing(CFCParamList *param_list) {
+S_gen_arg_parsing(CFCParamList *param_list, int first_tick, char **error) {
     char *content = NULL;
 
     CFCVariable **vars = CFCParamList_get_variables(param_list);
@@ -84,6 +84,21 @@ S_gen_arg_parsing(CFCParamList *param_list) {
     char *targets      = CFCUtil_strdup("");
     int optional_started = 0;
 
+    for (int i = first_tick; i < num_vars; i++) {
+        const char  *val  = vals[i];
+        if (val == NULL) {
+            if (optional_started) { // problem!
+                *error = "Required after optional param";
+                goto CLEAN_UP_AND_RETURN;
+            }
+        }
+        else {
+            if (!optional_started) {
+                optional_started = 1;
+            }
+        }
+    }
+
     char parse_pattern[] =
         "%s"
         "    char *keywords[] = {%sNULL};\n"
@@ -95,6 +110,7 @@ S_gen_arg_parsing(CFCParamList *param_list) {
     content = CFCUtil_sprintf(parse_pattern, declarations, keywords,
                               format_str, targets);
 
+CLEAN_UP_AND_RETURN:
     FREEMEM(declarations);
     FREEMEM(keywords);
     FREEMEM(format_str);
@@ -262,7 +278,14 @@ S_meth_top(CFCMethod *method) {
         return CFCUtil_sprintf(pattern);
     }
     else {
-        char *arg_parsing = S_gen_arg_parsing(param_list);
+        char *error = NULL;
+        char *arg_parsing = S_gen_arg_parsing(param_list, 1, &error);
+        if (error) {
+            CFCUtil_die("%s in %s", error, CFCMethod_get_name(method));
+        }
+        if (!arg_parsing) {
+            return NULL;
+        }
         char pattern[] =
             "(PyObject *self, PyObject *args, PyObject *kwargs) {\n"
             "%s"

--- a/compiler/src/CFCPyMethod.c
+++ b/compiler/src/CFCPyMethod.c
@@ -520,6 +520,24 @@ CFCPyMethod_wrapper(CFCMethod *method, CFCClass *invoker) {
 }
 
 char*
+CFCPyMethod_constructor_wrapper(CFCFunction *init_func, CFCClass *invoker) {
+    const char *struct_sym = CFCClass_full_struct_sym(invoker);
+
+    char pattern[] =
+        "static PyObject*\n"
+        "S_%s_PY_NEW(PyTypeObject *type, PyObject *args, PyObject *kwargs) {\n"
+        "    CFISH_UNUSED_VAR(type);\n"
+        "    CFISH_UNUSED_VAR(args);\n"
+        "    CFISH_UNUSED_VAR(kwargs);\n"
+        "    Py_RETURN_NONE;\n"
+        "}\n"
+        ;
+    char *wrapper = CFCUtil_sprintf(pattern, struct_sym);
+
+    return wrapper;
+}
+
+char*
 CFCPyMethod_pymethoddef(CFCMethod *method, CFCClass *invoker) {
     CFCParamList *param_list = CFCMethod_get_param_list(method);
     const char *flags = CFCParamList_num_vars(param_list) == 1

--- a/compiler/src/CFCPyMethod.c
+++ b/compiler/src/CFCPyMethod.c
@@ -215,20 +215,40 @@ S_maybe_unreachable(CFCType *return_type) {
     return return_statement;
 }
 
+static char*
+S_meth_top(CFCMethod *method) {
+    CFCParamList *param_list = CFCMethod_get_param_list(method);
+
+    if (CFCParamList_num_vars(param_list) == 1) {
+        char pattern[] =
+            "(PyObject *self, PyObject *unused) {\n"
+            "    CFISH_UNUSED_VAR(unused);\n"
+            ;
+        return CFCUtil_sprintf(pattern);
+    }
+    else {
+        char pattern[] =
+            "(PyObject *self, PyObject *args, PyObject *kwargs) {\n"
+            ;
+        char *result = CFCUtil_sprintf(pattern);
+        return result;
+    }
+}
+
 char*
 CFCPyMethod_wrapper(CFCMethod *method, CFCClass *invoker) {
     char *meth_sym   = CFCMethod_full_method_sym(method, invoker);
+    char *meth_top   = S_meth_top(method);
 
     char pattern[] =
         "static PyObject*\n"
-        "S_%s(PyObject *unused1, PyObject *unused2) {\n"
-        "    CFISH_UNUSED_VAR(unused1);\n"
-        "    CFISH_UNUSED_VAR(unused2);\n"
+        "S_%s%s"
         "    Py_RETURN_NONE;\n"
         "}\n"
         ;
-    char *wrapper = CFCUtil_sprintf(pattern, meth_sym);
+    char *wrapper = CFCUtil_sprintf(pattern, meth_sym, meth_top);
     FREEMEM(meth_sym);
+    FREEMEM(meth_top);
 
     return wrapper;
 }

--- a/compiler/src/CFCPyMethod.c
+++ b/compiler/src/CFCPyMethod.c
@@ -473,6 +473,26 @@ S_gen_decrefs(CFCParamList *param_list, int first_tick) {
     return decrefs;
 }
 
+static char*
+S_gen_arg_list(CFCParamList *param_list, const char *first_arg) {
+    CFCVariable **vars = CFCParamList_get_variables(param_list);
+    int num_vars = CFCParamList_num_vars(param_list);
+    char *arg_list = CFCUtil_strdup("");
+    for (int i = 0; i < num_vars; i++) {
+        if (i > 0) {
+            arg_list = CFCUtil_cat(arg_list, ", ", NULL);
+        }
+        if (i == 0 && first_arg != NULL) {
+            arg_list = CFCUtil_cat(arg_list, first_arg, NULL);
+        }
+        else {
+            arg_list = CFCUtil_cat(arg_list, CFCVariable_get_name(vars[i]),
+                                   "_ARG", NULL);
+        }
+    }
+    return arg_list;
+}
+
 char*
 CFCPyMethod_wrapper(CFCMethod *method, CFCClass *invoker) {
     CFCParamList *param_list  = CFCMethod_get_param_list(method);

--- a/compiler/src/CFCPyMethod.c
+++ b/compiler/src/CFCPyMethod.c
@@ -215,3 +215,21 @@ S_maybe_unreachable(CFCType *return_type) {
     return return_statement;
 }
 
+char*
+CFCPyMethod_wrapper(CFCMethod *method, CFCClass *invoker) {
+    char *meth_sym   = CFCMethod_full_method_sym(method, invoker);
+
+    char pattern[] =
+        "static PyObject*\n"
+        "S_%s(PyObject *unused1, PyObject *unused2) {\n"
+        "    CFISH_UNUSED_VAR(unused1);\n"
+        "    CFISH_UNUSED_VAR(unused2);\n"
+        "    Py_RETURN_NONE;\n"
+        "}\n"
+        ;
+    char *wrapper = CFCUtil_sprintf(pattern, meth_sym);
+    FREEMEM(meth_sym);
+
+    return wrapper;
+}
+

--- a/compiler/src/CFCPyMethod.c
+++ b/compiler/src/CFCPyMethod.c
@@ -124,7 +124,10 @@ S_gen_declaration(CFCVariable *var, const char *val) {
         }
     }
     else if (CFCType_is_primitive(type)) {
-        ;
+        if (val) {
+            char pattern[] = "    %s_ARG = %s;\n";
+            result = CFCUtil_sprintf(pattern, var_name, val);
+        }
     }
     else {
         CFCUtil_die("Unexpected type, can't gen declaration: %s", type_str);

--- a/compiler/src/CFCPyMethod.c
+++ b/compiler/src/CFCPyMethod.c
@@ -521,19 +521,33 @@ CFCPyMethod_wrapper(CFCMethod *method, CFCClass *invoker) {
 
 char*
 CFCPyMethod_constructor_wrapper(CFCFunction *init_func, CFCClass *invoker) {
+    CFCParamList *param_list  = CFCFunction_get_param_list(init_func);
+    char *decs       = S_gen_decs(param_list, 1);
     const char *struct_sym = CFCClass_full_struct_sym(invoker);
+    char *error = NULL;
+    char *arg_parsing = S_gen_arg_parsing(param_list, 1, &error);
+    if (error) {
+        CFCUtil_die("%s in constructor for %s", error,
+                    CFCClass_get_name(invoker));
+    }
+    if (!arg_parsing) {
+        CFCUtil_die("Unexpected arg parsing error for %s",
+                    CFCClass_get_name(invoker));
+    }
 
     char pattern[] =
         "static PyObject*\n"
         "S_%s_PY_NEW(PyTypeObject *type, PyObject *args, PyObject *kwargs) {\n"
-        "    CFISH_UNUSED_VAR(type);\n"
-        "    CFISH_UNUSED_VAR(args);\n"
-        "    CFISH_UNUSED_VAR(kwargs);\n"
+        "%s" // decs
+        "%s" // arg_parsing
         "    Py_RETURN_NONE;\n"
         "}\n"
         ;
-    char *wrapper = CFCUtil_sprintf(pattern, struct_sym);
+    char *wrapper = CFCUtil_sprintf(pattern, struct_sym, decs,
+                                    arg_parsing);
 
+    FREEMEM(decs);
+    FREEMEM(arg_parsing);
     return wrapper;
 }
 

--- a/compiler/src/CFCPyMethod.c
+++ b/compiler/src/CFCPyMethod.c
@@ -523,6 +523,8 @@ char*
 CFCPyMethod_constructor_wrapper(CFCFunction *init_func, CFCClass *invoker) {
     CFCParamList *param_list  = CFCFunction_get_param_list(init_func);
     char *decs       = S_gen_decs(param_list, 1);
+    char *increfs    = S_gen_arg_increfs(param_list, 1);
+    char *decrefs    = S_gen_decrefs(param_list, 1);
     const char *struct_sym = CFCClass_full_struct_sym(invoker);
     char *error = NULL;
     char *arg_parsing = S_gen_arg_parsing(param_list, 1, &error);
@@ -540,12 +542,16 @@ CFCPyMethod_constructor_wrapper(CFCFunction *init_func, CFCClass *invoker) {
         "S_%s_PY_NEW(PyTypeObject *type, PyObject *args, PyObject *kwargs) {\n"
         "%s" // decs
         "%s" // arg_parsing
+        "%s" // increfs
+        "%s" // decrefs
         "    Py_RETURN_NONE;\n"
         "}\n"
         ;
     char *wrapper = CFCUtil_sprintf(pattern, struct_sym, decs,
-                                    arg_parsing);
+                                    arg_parsing, increfs, decrefs);
 
+    FREEMEM(decrefs);
+    FREEMEM(increfs);
     FREEMEM(decs);
     FREEMEM(arg_parsing);
     return wrapper;

--- a/compiler/src/CFCPyMethod.h
+++ b/compiler/src/CFCPyMethod.h
@@ -21,6 +21,7 @@
 extern "C" {
 #endif
 
+struct CFCFunction;
 struct CFCMethod;
 struct CFCClass;
 
@@ -38,6 +39,12 @@ CFCPyMethod_pymethoddef(struct CFCMethod *method, struct CFCClass *invoker);
 
 char*
 CFCPyMethod_wrapper(struct CFCMethod *method, struct CFCClass *invoker);
+
+/** Generate glue code for a constructor.
+  */
+char*
+CFCPyMethod_constructor_wrapper(struct CFCFunction *init_func,
+                                struct CFCClass *invoker);
 
 #ifdef __cplusplus
 }

--- a/compiler/src/CFCPyMethod.h
+++ b/compiler/src/CFCPyMethod.h
@@ -31,6 +31,9 @@ struct CFCClass;
 char*
 CFCPyMethod_callback_def(struct CFCMethod *method, struct CFCClass *invoker);
 
+char*
+CFCPyMethod_wrapper(struct CFCMethod *method, struct CFCClass *invoker);
+
 #ifdef __cplusplus
 }
 #endif

--- a/compiler/src/CFCPyMethod.h
+++ b/compiler/src/CFCPyMethod.h
@@ -31,6 +31,11 @@ struct CFCClass;
 char*
 CFCPyMethod_callback_def(struct CFCMethod *method, struct CFCClass *invoker);
 
+/** Generate a PyMethodDef entry for an instance method.
+  */
+char*
+CFCPyMethod_pymethoddef(struct CFCMethod *method, struct CFCClass *invoker);
+
 char*
 CFCPyMethod_wrapper(struct CFCMethod *method, struct CFCClass *invoker);
 

--- a/runtime/python/cfext/CFBind.c
+++ b/runtime/python/cfext/CFBind.c
@@ -294,12 +294,13 @@ S_convert_obj(PyObject *py_obj, CFBindArg *arg, bool nullable) {
             return 0;
         }
     }
-    PyTypeObject *py_type = S_get_cached_py_type(arg->klass);
-    if (!PyObject_TypeCheck(py_obj, py_type)) {
+
+    bool success = S_maybe_py_to_cfish(py_obj, arg->klass, true, nullable,
+                                       NULL, arg->ptr);
+    if (!success) {
         PyErr_SetString(PyExc_TypeError, "Invalid argument type");
         return 0;
     }
-    *((PyObject**)arg->ptr) = py_obj;
     return 1;
 }
 

--- a/runtime/python/test/test_clownfish.py
+++ b/runtime/python/test/test_clownfish.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import unittest
+import inspect
 import clownfish
 
 class MyTest(unittest.TestCase):
@@ -23,6 +24,7 @@ class MyTest(unittest.TestCase):
 
     def testClassesPresent(self):
         self.assertIsInstance(clownfish.Hash, type)
+        self.assertTrue(inspect.ismethoddescriptor(clownfish.Hash.store))
 
 if __name__ == '__main__':
     unittest.main()

--- a/runtime/python/test/test_err.py
+++ b/runtime/python/test/test_err.py
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import clownfish
+import sys
+
+class TestErr(unittest.TestCase):
+
+    def testErrorHandling(self):
+        vec = clownfish.Vector()
+        try:
+            vec.grow(sys.maxsize)
+        except RuntimeError as e:
+            self.assertTrue(str(e).find("overflow") != -1)
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/runtime/python/test/test_hash.py
+++ b/runtime/python/test/test_hash.py
@@ -1,0 +1,102 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import inspect
+import clownfish
+
+class TestHash(unittest.TestCase):
+
+    def testStoreFetch(self):
+        h = clownfish.Hash()
+        h.store("foo", "bar")
+        h.store("foo", "bar")
+        self.assertEqual(h.fetch("foo"), "bar")
+        h.store("nada", None)
+        self.assertEqual(h.fetch("nada"), None)
+
+    def testDelete(self):
+        h = clownfish.Hash()
+        h.store("foo", "bar")
+        got = h.delete("foo")
+        self.assertEqual(h.get_size(), 0)
+        self.assertEqual(got, "bar")
+
+    def testClear(self):
+        h = clownfish.Hash()
+        h.store("foo", 1)
+        h.clear()
+        self.assertEqual(h.get_size(), 0)
+
+    def testHasKey(self):
+        h = clownfish.Hash()
+        h.store("foo", 1)
+        h.store("nada", None)
+        self.assertTrue(h.has_key("foo"))
+        self.assertFalse(h.has_key("bar"))
+        self.assertTrue(h.has_key("nada"))
+
+    def testKeys(self):
+        h = clownfish.Hash()
+        h.store("a", 1)
+        h.store("b", 1)
+        keys = sorted(h.keys())
+        self.assertEqual(keys, ["a", "b"])
+
+    def testValues(self):
+        h = clownfish.Hash()
+        h.store("foo", "a")
+        h.store("bar", "b")
+        got = sorted(h.values())
+        self.assertEqual(got, ["a", "b"])
+
+    def testGetCapacity(self):
+        h = clownfish.Hash(capacity=1)
+        self.assertGreater(h.get_capacity(), 0)
+
+    def testGetSize(self):
+        h = clownfish.Hash()
+        self.assertEqual(h.get_size(), 0)
+        h.store("meep", "moop")
+        self.assertEqual(h.get_size(), 1)
+
+    def testEquals(self):
+        h = clownfish.Hash()
+        other = clownfish.Hash()
+        h.store("a", "foo")
+        other.store("a", "foo")
+        self.assertTrue(h.equals(other))
+        other.store("b", "bar")
+        self.assertFalse(h.equals(other))
+        self.assertTrue(h.equals({"a":"foo"}),
+                        "equals() true against a Python dict")
+        vec = clownfish.Vector()
+        self.assertFalse(h.equals(vec),
+                         "equals() false against conflicting Clownfish type")
+        self.assertFalse(h.equals(1),
+                         "equals() false against conflicting Python type")
+
+    def testIterator(self):
+        h = clownfish.Hash()
+        h.store("a", "foo")
+        i = clownfish.HashIterator(h)
+        self.assertTrue(i.next())
+        self.assertEqual(i.get_key(), "a")
+        self.assertEqual(i.get_value(), "foo")
+        self.assertFalse(i.next())
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
Gen Py glue for methods and constructors.

* Autogenerate CPython glue code for methods and constructors.
* Handle both positional and labeled args.
* Deal with refcounting of args and return values.
* Trap Clownfish exceptions and rethrow as Python exceptions.
* Unit test Py binding of Hash.
