### PR TITLE
Perl build with make

### DIFF
--- a/compiler/perl/lib/Clownfish/CFC.xs
+++ b/compiler/perl/lib/Clownfish/CFC.xs
@@ -748,6 +748,12 @@ CODE:
 OUTPUT: RETVAL
 
 void
+write_log(self)
+    CFCHierarchy *self;
+PPCODE:
+    CFCHierarchy_write_log(self);
+
+void
 _set_or_get(self, ...)
     CFCHierarchy *self;
 ALIAS:

--- a/compiler/perl/lib/Clownfish/CFC/Perl/Build.pm
+++ b/compiler/perl/lib/Clownfish/CFC/Perl/Build.pm
@@ -64,16 +64,6 @@ sub new {
         $self->extra_linker_flags(@$extra_ldflags);
     }
 
-    my $cf_source = $self->clownfish_params('source');
-    if ( !defined($cf_source) ) {
-        $cf_source = [];
-    }
-    elsif ( !ref($cf_source) ) {
-        $cf_source = [ $cf_source ];
-    }
-    push( @$cf_source, catdir( $AUTOGEN_DIR, 'source' ) );
-    $self->clownfish_params( source => $cf_source );
-
     my $autogen_header = $self->clownfish_params('autogen_header');
     if ( !defined($autogen_header) ) {
         $self->clownfish_params( autogen_header => <<'END_AUTOGEN' );
@@ -409,7 +399,8 @@ sub ACTION_compile_custom_xs {
     else {
         my $c_files = [];
         my $source_dirs = $self->clownfish_params('source');
-        for my $source_dir (@$source_dirs) {
+        my $autogen_src_dir = catdir( $AUTOGEN_DIR, 'source' );
+        for my $source_dir ( @$source_dirs, $autogen_src_dir ) {
             push @$c_files, @{ $self->rscan_dir( $source_dir, qr/\.c$/ ) };
         }
         my $extra_cflags = $self->clownfish_params('cflags');

--- a/compiler/perl/lib/Clownfish/CFC/Perl/Build.pm
+++ b/compiler/perl/lib/Clownfish/CFC/Perl/Build.pm
@@ -348,6 +348,8 @@ sub ACTION_clownfish {
     {
         utime( time, time, $AUTOGEN_DIR );    # touch
     }
+
+    $hierarchy->write_log;
 }
 
 # Write ppport.h, which supplies some XS routines not found in older Perls and

--- a/runtime/perl/.gitignore
+++ b/runtime/perl/.gitignore
@@ -1,9 +1,11 @@
+
 *.pod
 /Build
 /Build.bat
 /Charmony.pm
 /MYMETA.json
 /MYMETA.yml
+/Makefile
 /_build/
 /autogen/
 /blib/
@@ -13,6 +15,6 @@
 /charmony.h
 /lib/Clownfish.c
 /lib/Clownfish.xs
+/libclownfish.*
 /ppport.h
 /typemap
-

--- a/runtime/perl/buildlib/Clownfish/Build.pm
+++ b/runtime/perl/buildlib/Clownfish/Build.pm
@@ -51,7 +51,6 @@ my @BASE_PATH = __PACKAGE__->cf_base_path;
 my $COMMON_SOURCE_DIR = catdir( @BASE_PATH, 'common' );
 my $CORE_SOURCE_DIR   = catdir( @BASE_PATH, 'core' );
 my $CFC_DIR           = catdir( @BASE_PATH, updir(), 'compiler', 'perl' );
-my $XS_SOURCE_DIR = 'xs';
 my $CFC_BUILD     = catfile( $CFC_DIR, 'Build' );
 my $LIB_DIR       = 'lib';
 my $CHARMONIZER_C;
@@ -64,7 +63,6 @@ else {
 
 sub new {
     my ( $class, %args ) = @_;
-    $args{include_dirs}     = [ $CORE_SOURCE_DIR, $XS_SOURCE_DIR ];
     $args{clownfish_params} = {
         autogen_header => _autogen_header(),
         include        => [],                  # Don't use default includes.

--- a/runtime/perl/buildlib/Clownfish/Build.pm
+++ b/runtime/perl/buildlib/Clownfish/Build.pm
@@ -68,7 +68,7 @@ sub new {
     $args{clownfish_params} = {
         autogen_header => _autogen_header(),
         include        => [],                  # Don't use default includes.
-        source => [ $CORE_SOURCE_DIR, $XS_SOURCE_DIR ],
+        source         => [ $CORE_SOURCE_DIR ],
     };
     my $self = $class->SUPER::new( recursive_test_files => 1, %args );
 
@@ -83,9 +83,21 @@ sub new {
         $self->extra_compiler_flags(@$extra_cflags);
     }
 
+    $self->charmonizer_params( create_makefile => 1 );
     $self->charmonizer_params( charmonizer_c => $CHARMONIZER_C );
 
     return $self;
+}
+
+sub source_spec {
+    my $self = shift;
+
+    $self->depends_on('charmony');
+
+    return {
+        build_with_make => 1,
+        lib_filename    => $self->charmony('STATIC_LIB_FILENAME'),
+    };
 }
 
 sub _run_make {


### PR DESCRIPTION
Create a static library of the core C code using the Makefile generated by charmonizer and link the result with the compiled XS code. This makes it possible to speed up the build of the Perl runtime by running make jobs in parallel. It also centralizes the selection of C source files which becomes important when building multiple binaries.