### PR TITLE
Add class array to CFCParcel

### DIFF
--- a/compiler/c/cfc.c
+++ b/compiler/c/cfc.c
@@ -263,7 +263,6 @@ main(int argc, char **argv) {
     FREEMEM(header);
     FREEMEM(footer);
 
-    CFCClass_clear_registry();
     CFCDocument_clear_registry();
     CFCParcel_reap_singletons();
 

--- a/compiler/perl/lib/Clownfish/CFC.pm
+++ b/compiler/perl/lib/Clownfish/CFC.pm
@@ -22,7 +22,6 @@ $VERSION = eval $VERSION;
 our $MAJOR_VERSION = 0.006000;
 
 END {
-    Clownfish::CFC::Model::Class->_clear_registry();
     Clownfish::CFC::Model::Parcel->reap_singletons();
 }
 

--- a/compiler/perl/lib/Clownfish/CFC.pm
+++ b/compiler/perl/lib/Clownfish/CFC.pm
@@ -250,7 +250,7 @@ BEGIN { XSLoader::load( 'Clownfish::CFC', '0.6.0' ) }
         param_list  => undef,
         name        => undef,
         docucomment => undef,
-        class_name  => undef,
+        class       => undef,
         abstract    => undef,
         final       => undef,
         exposure    => 'parcel',
@@ -264,7 +264,7 @@ BEGIN { XSLoader::load( 'Clownfish::CFC', '0.6.0' ) }
         $args{final}    ||= 0;
         return _new(
             @args{
-                qw( exposure name return_type param_list docucomment class_name
+                qw( exposure name return_type param_list docucomment class
                     final abstract )
                 }
         );

--- a/compiler/perl/lib/Clownfish/CFC.xs
+++ b/compiler/perl/lib/Clownfish/CFC.xs
@@ -1150,12 +1150,27 @@ PPCODE:
     CFCParcel_add_class(self, klass);
 
 SV*
-lookup_struct_sym(self, struct_sym)
-    CFCParcel  *self;
-    const char *struct_sym;
+_fetch_class(self, string)
+    CFCParcel *self;
+    const char *string;
+ALIAS:
+    class              = 1
+    class_by_short_sym = 2
+    class_by_full_sym  = 3
 CODE:
-    CFCParcel *parcel = CFCParcel_lookup_struct_sym(self, struct_sym);
-    RETVAL = S_cfcbase_to_perlref(parcel);
+    CFCClass *klass = NULL;
+    switch (ix) {
+        case 1:
+            klass = CFCParcel_class(self, string);
+            break;
+        case 2:
+            klass = CFCParcel_class_by_short_sym(self, string);
+            break;
+        case 3:
+            klass = CFCParcel_class_by_full_sym(self, string);
+            break;
+    }
+    RETVAL = S_cfcbase_to_perlref(klass);
 OUTPUT: RETVAL
 
 void

--- a/compiler/perl/lib/Clownfish/CFC.xs
+++ b/compiler/perl/lib/Clownfish/CFC.xs
@@ -1193,6 +1193,7 @@ ALIAS:
     prereq_parcels    = 20
     inherited_parcels = 22
     get_xs_module     = 24
+    get_classes       = 26
 PPCODE:
 {
     START_SET_OR_GET_SWITCH
@@ -1249,6 +1250,11 @@ PPCODE:
         case 24: {
                 const char *xs_module = CFCParcel_get_host_module_name(self);
                 retval = newSVpvn(xs_module, strlen(xs_module));
+            }
+            break;
+        case 26: {
+                CFCClass **classes = CFCParcel_get_classes(self);
+                retval = S_array_of_cfcbase_to_av((CFCBase**)classes);
             }
             break;
     END_SET_OR_GET_SWITCH

--- a/compiler/perl/lib/Clownfish/CFC.xs
+++ b/compiler/perl/lib/Clownfish/CFC.xs
@@ -1097,13 +1097,6 @@ CODE:
     RETVAL = S_array_of_cfcbase_to_av((CFCBase**)all_parcels);
 OUTPUT: RETVAL
 
-void
-add_inherited_parcel(self, inherited)
-    CFCParcel *self;
-    CFCParcel *inherited;
-PPCODE:
-    CFCParcel_add_inherited_parcel(self, inherited);
-
 int
 has_prereq(self, parcel)
     CFCParcel *self;
@@ -1162,7 +1155,6 @@ ALIAS:
     get_prereqs       = 14
     included          = 16
     prereq_parcels    = 20
-    inherited_parcels = 22
     get_xs_module     = 24
     get_classes       = 26
 PPCODE:
@@ -1208,12 +1200,6 @@ PPCODE:
             break;
         case 20: {
                 CFCParcel **parcels = CFCParcel_prereq_parcels(self);
-                retval = S_array_of_cfcbase_to_av((CFCBase**)parcels);
-                FREEMEM(parcels);
-            }
-            break;
-        case 22: {
-                CFCParcel **parcels = CFCParcel_inherited_parcels(self);
                 retval = S_array_of_cfcbase_to_av((CFCBase**)parcels);
                 FREEMEM(parcels);
             }

--- a/compiler/perl/lib/Clownfish/CFC.xs
+++ b/compiler/perl/lib/Clownfish/CFC.xs
@@ -2423,17 +2423,18 @@ CODE:
 OUTPUT: RETVAL
 
 SV*
-_gen_subroutine_pod(func, alias, klass, code_sample, class_name, is_constructor)
+_gen_subroutine_pod(func, alias, klass, code_sample, class_name, is_constructor, docucomment, base_class)
     CFCCallable *func;
     const char *alias;
     CFCClass *klass;
     const char *code_sample;
-    const char *class_name;
     int is_constructor;
+    CFCDocuComment *docucomment;
+    CFCClass *base_class;
 CODE:
     char *value = CFCPerlPod_gen_subroutine_pod(func, alias, klass,
-                                                code_sample, class_name,
-                                                is_constructor);
+                                                code_sample, is_constructor,
+                                                docucomment, base_class);
     RETVAL = S_sv_eat_c_string(value);
 OUTPUT: RETVAL
 

--- a/compiler/perl/lib/Clownfish/CFC.xs
+++ b/compiler/perl/lib/Clownfish/CFC.xs
@@ -183,22 +183,6 @@ CODE:
     CFCBase_decref((CFCBase*)self);
 OUTPUT: RETVAL
 
-SV*
-fetch_singleton(unused, class_name)
-    SV *unused;
-    const char *class_name;
-CODE:
-    CHY_UNUSED_VAR(unused);
-    CFCClass *klass = CFCClass_fetch_singleton(class_name);
-    RETVAL = S_cfcbase_to_perlref(klass);
-OUTPUT: RETVAL
-
-void
-_clear_registry(...)
-PPCODE:
-    CHY_UNUSED_VAR(items);
-    CFCClass_clear_registry();
-
 void
 add_child(self, child)
     CFCClass *self;

--- a/compiler/perl/lib/Clownfish/CFC.xs
+++ b/compiler/perl/lib/Clownfish/CFC.xs
@@ -1157,11 +1157,11 @@ CODE:
 OUTPUT: RETVAL
 
 void
-add_struct_sym(self, struct_sym)
-    CFCParcel  *self;
-    const char *struct_sym;
+add_class(self, klass)
+    CFCParcel *self;
+    CFCClass  *klass;
 PPCODE:
-    CFCParcel_add_struct_sym(self, struct_sym);
+    CFCParcel_add_class(self, klass);
 
 SV*
 lookup_struct_sym(self, struct_sym)

--- a/compiler/perl/lib/Clownfish/CFC.xs
+++ b/compiler/perl/lib/Clownfish/CFC.xs
@@ -297,7 +297,6 @@ ALIAS:
     methods               = 36
     member_vars           = 38
     inert_vars            = 40
-    tree_to_ladder        = 42
     fresh_methods         = 44
     fresh_member_vars     = 46
     privacy_symbol        = 48
@@ -398,12 +397,6 @@ PPCODE:
         case 40:
             retval = S_array_of_cfcbase_to_av((CFCBase**)CFCClass_inert_vars(self));
             break;
-        case 42: {
-                CFCClass **ladder = CFCClass_tree_to_ladder(self);
-                retval = S_array_of_cfcbase_to_av((CFCBase**)ladder);
-                FREEMEM(ladder);
-                break;
-            }
         case 44: {
                 CFCMethod **fresh = CFCClass_fresh_methods(self);
                 retval = S_array_of_cfcbase_to_av((CFCBase**)fresh);
@@ -792,7 +785,6 @@ ALIAS:
     get_include_dest  = 4
     get_source_dest   = 6
     files             = 8
-    ordered_classes   = 10
     get_source_dirs   = 12
     get_include_dirs  = 14
 PPCODE:
@@ -816,12 +808,6 @@ PPCODE:
         case 8:
             retval = S_array_of_cfcbase_to_av(
                 (CFCBase**)CFCHierarchy_files(self));
-            break;
-        case 10: {
-                CFCClass **ladder = CFCHierarchy_ordered_classes(self);
-                retval = S_array_of_cfcbase_to_av((CFCBase**)ladder);
-                FREEMEM(ladder);
-            }
             break;
         case 12: {
                 const char **source_dirs = CFCHierarchy_get_source_dirs(self);

--- a/compiler/perl/lib/Clownfish/CFC.xs
+++ b/compiler/perl/lib/Clownfish/CFC.xs
@@ -826,23 +826,21 @@ PPCODE:
 MODULE = Clownfish::CFC   PACKAGE = Clownfish::CFC::Model::Method
 
 SV*
-_new(exposure_sv, name, return_type, param_list, docucomment, class_name_sv, is_final, is_abstract)
+_new(exposure_sv, name, return_type, param_list, docucomment, klass, is_final, is_abstract)
     SV *exposure_sv;
     const char *name;
     CFCType *return_type;
     CFCParamList *param_list;
     CFCDocuComment *docucomment;
-    SV *class_name_sv;
+    CFCClass *klass;
     int is_final;
     int is_abstract;
 CODE:
     const char *exposure =
         SvOK(exposure_sv) ? SvPV_nolen(exposure_sv) : NULL;
-    const char *class_name =
-        SvOK(class_name_sv) ? SvPV_nolen(class_name_sv) : NULL;
     CFCMethod *self
         = CFCMethod_new(exposure, name, return_type, param_list, docucomment,
-                        class_name, is_final, is_abstract);
+                        klass, is_final, is_abstract);
     RETVAL = S_cfcbase_to_perlref(self);
     CFCBase_decref((CFCBase*)self);
 OUTPUT: RETVAL

--- a/compiler/perl/lib/Clownfish/CFC.xs
+++ b/compiler/perl/lib/Clownfish/CFC.xs
@@ -2509,11 +2509,11 @@ PPCODE:
     CFCParser_set_parcel(self, parcel);
 
 void
-set_class_name(self, class_name)
-    CFCParser  *self;
-    const char *class_name;
+set_class(self, klass)
+    CFCParser *self;
+    CFCClass  *klass;
 PPCODE:
-    CFCParser_set_class_name(self, class_name);
+    CFCParser_set_class(self, klass);
 
 SV*
 get_parcel(self)

--- a/compiler/perl/lib/Clownfish/CFC.xs
+++ b/compiler/perl/lib/Clownfish/CFC.xs
@@ -264,7 +264,6 @@ ALIAS:
     get_exposure          = 2
     get_name              = 4
     get_nickname          = 6
-    set_parent            = 7
     get_parent            = 8
     get_path_part         = 10
     get_parent_class_name = 12
@@ -303,17 +302,6 @@ PPCODE:
                 retval = newSVpvn(value, strlen(value));
             }
             break;
-        case 7: {
-                CFCClass *parent = NULL;
-                if (SvOK(ST(1))
-                    && sv_derived_from(ST(1), "Clownfish::CFC::Model::Class")
-                   ) {
-                    IV objint = SvIV((SV*)SvRV(ST(1)));
-                    parent = INT2PTR(CFCClass*, objint);
-                }
-                CFCClass_set_parent(self, parent);
-                break;
-            }
         case 8: {
                 CFCClass *parent = CFCClass_get_parent(self);
                 retval = S_cfcbase_to_perlref(parent);

--- a/compiler/perl/t/200-function.t
+++ b/compiler/perl/t/200-function.t
@@ -44,7 +44,11 @@ like( $@, qr/extra_arg/, "Extra arg kills constructor" );
 eval { Clownfish::CFC::Model::Function->new( %args, name => 'Uh_Oh' ); };
 like( $@, qr/Uh_Oh/, "invalid name kills constructor" );
 
-$parser->set_class_name("Neato::Obj");
+my $neato_obj = Clownfish::CFC::Model::Class->create(
+    parcel     => "Neato",
+    class_name => "Neato::Obj",
+);
+$parser->set_class($neato_obj);
 isa_ok(
     $parser->parse($_),
     "Clownfish::CFC::Model::Function",

--- a/compiler/perl/t/201-method.t
+++ b/compiler/perl/t/201-method.t
@@ -16,7 +16,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 38;
+use Test::More tests => 30;
 
 BEGIN { use_ok('Clownfish::CFC::Model::Method') }
 use Clownfish::CFC::Parser;
@@ -24,10 +24,11 @@ use Clownfish::CFC::Parser;
 my $parser = Clownfish::CFC::Parser->new;
 $parser->parse('parcel Neato;')
     or die "failed to process parcel_definition";
+my $neato_foo = $parser->parse('class Neato::Foo {}');
 
 my %args = (
     return_type => $parser->parse('Obj*'),
-    class_name  => 'Neato::Foo',
+    class       => $neato_foo,
     param_list  => $parser->parse('(Foo *self, int32_t count = 0)'),
     name        => 'Return_An_Obj',
 );
@@ -47,24 +48,6 @@ eval {
     Clownfish::CFC::Model::Method->new( %args, name => 'return_an_obj' );
 };
 like( $@, qr/name/, "Invalid name kills constructor" );
-
-for (qw( foo 1Foo Foo_Bar 1FOOBAR )) {
-    eval {
-        Clownfish::CFC::Model::Method->new(
-            %args,
-            class_name => $_,
-        );
-    };
-    like( $@, qr/class_name/, "Reject invalid class name $_" );
-    my $bogus_middle = "Foo::" . $_ . "::Bar";
-    eval {
-        Clownfish::CFC::Model::Method->new(
-            %args,
-            class_name => $bogus_middle,
-        );
-    };
-    like( $@, qr/class_name/, "Reject invalid class name $bogus_middle" );
-}
 
 my $dupe = Clownfish::CFC::Model::Method->new(%args);
 ok( $method->compatible($dupe), "compatible()" );
@@ -113,7 +96,7 @@ ok( !$param_type_differs->compatible($method), "... reversed" );
 
 my $self_type_differs = Clownfish::CFC::Model::Method->new(
     %args,
-    class_name => 'Neato::Bar',
+    class      => $parser->parse('class Neato::Bar {}'),
     param_list => $parser->parse('(Bar *self, int32_t count = 0)'),
 );
 ok( $method->compatible($self_type_differs),

--- a/compiler/perl/t/201-method.t
+++ b/compiler/perl/t/201-method.t
@@ -133,7 +133,11 @@ for my $meth_meth (qw( short_method_sym full_method_sym full_offset_sym)) {
     like( $@, qr/invoker/, "$meth_meth requires invoker" );
 }
 
-$parser->set_class_name("Neato::Obj");
+my $neato_obj = Clownfish::CFC::Model::Class->create(
+    parcel     => "Neato",
+    class_name => "Neato::Obj",
+);
+$parser->set_class($neato_obj);
 isa_ok(
     $parser->parse($_),
     "Clownfish::CFC::Model::Method",

--- a/compiler/perl/t/202-overridden_method.t
+++ b/compiler/perl/t/202-overridden_method.t
@@ -27,7 +27,7 @@ $parser->parse('parcel Neato;')
 
 my %args = (
     return_type => $parser->parse('Obj*'),
-    class_name  => 'Neato::Foo',
+    class       => $parser->parse('class Neato::Foo {}'),
     param_list  => $parser->parse('(Foo *self)'),
     name        => 'Return_An_Obj',
 );
@@ -36,7 +36,7 @@ my $orig      = Clownfish::CFC::Model::Method->new(%args);
 my $overrider = Clownfish::CFC::Model::Method->new(
     %args,
     param_list => $parser->parse('(FooJr *self)'),
-    class_name => 'Neato::Foo::FooJr',
+    class      => $parser->parse('class Neato::Foo::FooJr {}'),
 );
 $overrider->override($orig);
 ok( !$overrider->novel, "A Method which overrides another is not 'novel'" );

--- a/compiler/perl/t/203-final_method.t
+++ b/compiler/perl/t/203-final_method.t
@@ -26,7 +26,7 @@ $parser->parse('parcel Neato;')
 
 my %args = (
     return_type => $parser->parse('Obj*'),
-    class_name  => 'Neato::Foo',
+    class       => $parser->parse('class Neato::Foo {}'),
     param_list  => $parser->parse('(Foo* self)'),
     name        => 'Return_An_Obj',
 );

--- a/compiler/perl/t/401-class.t
+++ b/compiler/perl/t/401-class.t
@@ -242,7 +242,6 @@ $class_content = qq|
 $class = $parser->parse($class_content);
 ok( $class->final, "final class_declaration" );
 
-Clownfish::CFC::Model::Class->_clear_registry();
 Clownfish::CFC::Model::Parcel->reap_singletons();
 
 {
@@ -253,7 +252,6 @@ Clownfish::CFC::Model::Parcel->reap_singletons();
     };
     like( $@, qr/inert class/i, "inert class can't inherit" );
 
-    Clownfish::CFC::Model::Class->_clear_registry();
     Clownfish::CFC::Model::Parcel->reap_singletons();
 }
 
@@ -265,7 +263,6 @@ Clownfish::CFC::Model::Parcel->reap_singletons();
     };
     like( $@, qr/inert class/i, "can't inherit from inert class" );
 
-    Clownfish::CFC::Model::Class->_clear_registry();
     Clownfish::CFC::Model::Parcel->reap_singletons();
 }
 

--- a/compiler/perl/t/401-class.t
+++ b/compiler/perl/t/401-class.t
@@ -16,7 +16,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 54;
+use Test::More tests => 53;
 use Clownfish::CFC::Model::Class;
 use Clownfish::CFC::Parser;
 
@@ -149,9 +149,6 @@ is_deeply( $foo_jr->functions,         [], "don't inherit inert funcs" );
 is_deeply( $foo_jr->fresh_member_vars, [], "fresh_member_vars" );
 is_deeply( $foo_jr->inert_vars,        [], "don't inherit inert vars" );
 is_deeply( $final_foo->fresh_methods,  [], "fresh_methods" );
-
-is_deeply( $foo->tree_to_ladder, [ $foo, $foo_jr, $final_foo ],
-    'tree_to_ladder' );
 
 ok( $parser->parse("$_ class Iam$_ { }")->$_, "class_modifier: $_" )
     for (qw( final inert ));

--- a/compiler/perl/t/401-class.t
+++ b/compiler/perl/t/401-class.t
@@ -246,6 +246,7 @@ $class = $parser->parse($class_content);
 ok( $class->final, "final class_declaration" );
 
 Clownfish::CFC::Model::Class->_clear_registry();
+Clownfish::CFC::Model::Parcel->reap_singletons();
 
 {
     eval {
@@ -256,6 +257,7 @@ Clownfish::CFC::Model::Class->_clear_registry();
     like( $@, qr/inert class/i, "inert class can't inherit" );
 
     Clownfish::CFC::Model::Class->_clear_registry();
+    Clownfish::CFC::Model::Parcel->reap_singletons();
 }
 
 {
@@ -267,5 +269,6 @@ Clownfish::CFC::Model::Class->_clear_registry();
     like( $@, qr/inert class/i, "can't inherit from inert class" );
 
     Clownfish::CFC::Model::Class->_clear_registry();
+    Clownfish::CFC::Model::Parcel->reap_singletons();
 }
 

--- a/compiler/perl/t/401-class.t
+++ b/compiler/perl/t/401-class.t
@@ -21,7 +21,7 @@ use Clownfish::CFC::Model::Class;
 use Clownfish::CFC::Parser;
 
 my $parser = Clownfish::CFC::Parser->new;
-$parser->parse('parcel Neato;');
+my $neato = $parser->parse('parcel Neato;');
 
 my $thing = Clownfish::CFC::Model::Variable->new(
     type => $parser->parse('Thing*'),
@@ -45,8 +45,8 @@ my $foo = Clownfish::CFC::Model::Class->create(%foo_create_args);
 $foo->add_function($tread_water);
 $foo->add_member_var($thing);
 $foo->add_inert_var($widget);
-my $should_be_foo = Clownfish::CFC::Model::Class->fetch_singleton('Foo');
-is( $$foo, $$should_be_foo, "fetch_singleton" );
+my $should_be_foo = $neato->class('Foo');
+is( $$foo, $$should_be_foo, "Fetch class from parcel" );
 
 eval { Clownfish::CFC::Model::Class->create(%foo_create_args) };
 like( $@, qr/two classes with name/i,

--- a/compiler/perl/t/401-class.t
+++ b/compiler/perl/t/401-class.t
@@ -99,24 +99,24 @@ is( $final_foo->get_parent_class_name, 'Foo::FooJr',
     "get_parent_class_name" );
 
 $parser->parse("parcel Neato;");
-$parser->set_class_name("Foo");
+$parser->set_class($foo);
 my $do_stuff = $parser->parse('void Do_Stuff(Foo *self);')
     or die "parsing failure";
 $foo->add_method($do_stuff);
-
-$parser->set_class_name("InertFoo");
-my $inert_do_stuff = $parser->parse('void Do_Stuff(InertFoo *self);')
-    or die "parsing failure";
-$parser->set_class_name("");
 
 my %inert_args = (
     parcel     => 'Neato',
     class_name => 'InertFoo',
     inert      => 1,
 );
+my $inert_foo = Clownfish::CFC::Model::Class->create(%inert_args);
+$parser->set_class($inert_foo);
+my $inert_do_stuff = $parser->parse('void Do_Stuff(InertFoo *self);')
+    or die "parsing failure";
+$parser->set_class(undef);
+
 eval {
-    my $class = Clownfish::CFC::Model::Class->create(%inert_args);
-    $class->add_method($inert_do_stuff);
+    $inert_foo->add_method($inert_do_stuff);
 };
 like(
     $@,

--- a/compiler/perl/t/403-parcel.t
+++ b/compiler/perl/t/403-parcel.t
@@ -18,7 +18,7 @@ use warnings;
 use lib 'buildlib';
 
 use Clownfish::CFC::Test::TestUtils qw( test_files_dir );
-use Test::More tests => 32;
+use Test::More tests => 31;
 use File::Spec::Functions qw( catdir );
 
 BEGIN { use_ok('Clownfish::CFC::Model::Prereq') }
@@ -70,10 +70,6 @@ $included_foo->register;
 my $parcels = Clownfish::CFC::Model::Parcel->all_parcels;
 my @names = sort(map { $_->get_name } @$parcels);
 is_deeply( \@names, [ "Foo", "IncludedFoo" ], "all_parcels" );
-
-$foo->add_inherited_parcel($included_foo);
-my @inh_names = sort(map { $_->get_name } @{ $foo->inherited_parcels });
-is_deeply( \@inh_names, [ "IncludedFoo" ], "inherited_parcels" );
 
 my $json = qq|
         {

--- a/compiler/perl/t/403-parcel.t
+++ b/compiler/perl/t/403-parcel.t
@@ -192,9 +192,20 @@ Clownfish::CFC::Model::Parcel->reap_singletons();
     ok( $crust->has_prereq($crust), 'has_prereq self' );
     ok( !$crust->has_prereq($foo), 'has_prereq false' );
 
-    $cfish->add_struct_sym('Swim');
-    $crust->add_struct_sym('Pinch');
-    $foo->add_struct_sym('Bar');
+    Clownfish::CFC::Model::Class->create(
+        parcel     => $cfish,
+        file_spec  => $cfish_file_spec,
+        class_name => 'Clownfish::Swim',
+    );
+    Clownfish::CFC::Model::Class->create(
+        parcel     => $crust,
+        class_name => 'Crustacean::Pinch',
+    );
+    Clownfish::CFC::Model::Class->create(
+        parcel     => $foo,
+        file_spec  => $foo_file_spec,
+        class_name => 'Foo::Bar',
+    );
     my $found;
     $found = $crust->lookup_struct_sym('Swim');
     is( $found->get_name, 'Clownfish', 'lookup_struct_sym prereq' );

--- a/compiler/perl/t/403-parcel.t
+++ b/compiler/perl/t/403-parcel.t
@@ -206,13 +206,13 @@ Clownfish::CFC::Model::Parcel->reap_singletons();
         file_spec  => $foo_file_spec,
         class_name => 'Foo::Bar',
     );
-    my $found;
-    $found = $crust->lookup_struct_sym('Swim');
-    is( $found->get_name, 'Clownfish', 'lookup_struct_sym prereq' );
-    $found = $crust->lookup_struct_sym('Pinch');
-    is( $found->get_name, 'Crustacean', 'lookup_struct_sym self' );
-    $found = $crust->lookup_struct_sym('Bar');
-    ok( !$found, 'lookup_struct_sym other' );
+    my $class;
+    $class = $crust->class_by_short_sym('Swim');
+    is( $class->get_name, 'Clownfish::Swim', 'class_by_short_sym prereq' );
+    $class = $crust->class_by_short_sym('Pinch');
+    is( $class->get_name, 'Crustacean::Pinch', 'class_by_short_sym self' );
+    $class = $crust->class_by_short_sym('Bar');
+    ok( !$class, 'class_by_short_sym other' );
 
     Clownfish::CFC::Model::Parcel->reap_singletons();
 }

--- a/compiler/perl/t/404-file.t
+++ b/compiler/perl/t/404-file.t
@@ -88,8 +88,6 @@ my $file_spec = Clownfish::CFC::Model::FileSpec->new(
     isa_ok( $blocks->[1], "Clownfish::CFC::Model::Class" );
     isa_ok( $blocks->[2], "Clownfish::CFC::Model::Class" );
     isa_ok( $blocks->[3], "Clownfish::CFC::Model::CBlock" );
-
-    Clownfish::CFC::Model::Class->_clear_registry();
 }
 
 

--- a/compiler/perl/t/500-hierarchy.t
+++ b/compiler/perl/t/500-hierarchy.t
@@ -17,7 +17,7 @@ use strict;
 use warnings;
 use lib 'buildlib';
 
-use Test::More tests => 21;
+use Test::More tests => 22;
 
 use Clownfish::CFC::Model::Hierarchy;
 use Clownfish::CFC::Util qw( a_isa_b );
@@ -70,7 +70,9 @@ my $animal = $files{'Animal'}       or die "No Animal";
 my $dog    = $files{'Animal::Dog'}  or die "No Dog";
 my $util   = $files{'Animal::Util'} or die "No Util";
 
-my $classes = $hierarchy->ordered_classes;
+my $parcel = Clownfish::CFC::Model::Parcel->fetch('Animal');
+ok( $parcel, "Fetch parcel Animal" );
+my $classes = $parcel->get_classes;
 is( scalar @$classes, 4, "all classes" );
 for my $class (@$classes) {
     die "not a Class" unless isa_ok( $class, "Clownfish::CFC::Model::Class" );

--- a/compiler/perl/t/600-parser.t
+++ b/compiler/perl/t/600-parser.t
@@ -143,7 +143,7 @@ SKIP: {
 }
 
 is( $parser->parse("class $_ { }")->get_name, $_, "class_name: $_" )
-    for (qw( Foo Foo::FooJr Foo::FooJr::FooIII Foo::FooJr::FooIII::Foo4th ));
+    for (qw( Moo Moo::MooJr Moo::MooJr::MooIII Moo::MooJr::MooIII::Moo4th ));
 
 SKIP: {
     skip( "Can't recover from bad class name under flex/lemon parser", 6 );

--- a/compiler/perl/t/600-parser.t
+++ b/compiler/perl/t/600-parser.t
@@ -121,10 +121,14 @@ is_deeply(
     "initial values"
 );
 
-$parser->set_class_name('Stuff::Obj');
+my $stuff_obj = Clownfish::CFC::Model::Class->create(
+    parcel     => "Crustacean",
+    class_name => "Crust::Stuff",
+);
+$parser->set_class($stuff_obj);
 ok( $parser->parse($_), "declaration statement: $_" )
     for (
-    'public Foo* Spew_Foo(Obj *self, uint32_t *how_many);',
+    'public Foo* Spew_Foo(Stuff *self, uint32_t *how_many);',
     'public inert Hash *hash;',
     );
 

--- a/compiler/perl/t/600-parser.t
+++ b/compiler/perl/t/600-parser.t
@@ -138,7 +138,6 @@ for (qw( Foo FooJr FooIII Foo4th )) {
     $type->resolve;
     is( $type->get_specifier, "crust_$_", "object_type_specifier: $_" )
 }
-Clownfish::CFC::Model::Class->_clear_registry();
 
 SKIP: {
     skip( "Can't recover from bad specifier under flex/lemon parser", 6 );

--- a/compiler/src/CFCBase.h
+++ b/compiler/src/CFCBase.h
@@ -28,18 +28,23 @@ extern "C" {
 
 typedef struct CFCBase CFCBase;
 typedef struct CFCMeta CFCMeta;
+typedef struct CFCWeakPtr CFCWeakPtr;
 typedef void (*CFCBase_destroy_t)(CFCBase *self);
 
 #ifdef CFC_NEED_BASE_STRUCT_DEF
 struct CFCBase {
     const CFCMeta *meta;
     unsigned refcount;
+    unsigned weak_refcount;
 };
 #endif
 struct CFCMeta {
     const char *cfc_class;
     size_t obj_alloc_size;
     CFCBase_destroy_t destroy;
+};
+struct CFCWeakPtr {
+    CFCBase *ptr_;
 };
 
 /** Allocate a new CFC object.
@@ -80,6 +85,18 @@ CFCBase_get_refcount(CFCBase *self);
  */
 const char*
 CFCBase_get_cfc_class(CFCBase *self);
+
+CFCWeakPtr
+CFCWeakPtr_new(CFCBase *base);
+
+CFCBase*
+CFCWeakPtr_deref(CFCWeakPtr self);
+
+void
+CFCWeakPtr_set(CFCWeakPtr *self, CFCBase *base);
+
+void
+CFCWeakPtr_destroy(CFCWeakPtr *self);
 
 #ifdef __cplusplus
 }

--- a/compiler/src/CFCBindMethod.c
+++ b/compiler/src/CFCBindMethod.c
@@ -165,8 +165,7 @@ char*
 CFCBindMeth_abstract_method_def(CFCMethod *method, CFCClass *klass) {
     CFCType    *ret_type      = CFCMethod_get_return_type(method);
     const char *ret_type_str  = CFCType_to_c(ret_type);
-    CFCType    *type          = CFCMethod_self_type(method);
-    const char *class_var     = CFCType_get_class_var(type);
+    const char *class_var     = CFCClass_full_class_var(klass);
     const char *meth_name     = CFCMethod_get_name(method);
     CFCParamList *param_list  = CFCMethod_get_param_list(method);
     const char *params        = CFCParamList_to_c(param_list);

--- a/compiler/src/CFCBindMethod.c
+++ b/compiler/src/CFCBindMethod.c
@@ -32,44 +32,8 @@
   #define false 0
 #endif
 
-static char*
-S_method_def(CFCMethod *method, CFCClass *klass, int optimized_final_meth);
-
-/* Create a method invocation routine that resolves to a function name
- * directly, since this method may not be overridden.
- */
-static char*
-S_optimized_final_method_def(CFCMethod *method, CFCClass *klass) {
-    return S_method_def(method, klass, true);
-}
-
-/* Create a method invocation routine which uses vtable dispatch.
- */
-static char*
-S_virtual_method_def(CFCMethod *method, CFCClass *klass) {
-    return S_method_def(method, klass, false);
-}
-
 char*
 CFCBindMeth_method_def(CFCMethod *method, CFCClass *klass) {
-    // If the method is final and the class where it is declared final is in
-    // the same parcel as the invocant, we can optimize the call by resolving
-    // to the implementing function directly.
-    if (CFCMethod_final(method)) {
-        CFCClass *ancestor = klass;
-        while (ancestor && !CFCMethod_is_fresh(method, ancestor)) {
-            ancestor = CFCClass_get_parent(ancestor);
-        }
-        if (CFCClass_get_parcel(ancestor) == CFCClass_get_parcel(klass)) {
-            return S_optimized_final_method_def(method, klass);
-        }
-    }
-
-    return S_virtual_method_def(method, klass);
-}
-
-static char*
-S_method_def(CFCMethod *method, CFCClass *klass, int optimized_final_meth) {
     CFCParamList *param_list = CFCMethod_get_param_list(method);
     const char *PREFIX         = CFCClass_get_PREFIX(klass);
     const char *invoker_struct = CFCClass_full_struct_sym(klass);
@@ -94,6 +58,20 @@ S_method_def(CFCMethod *method, CFCClass *klass, int optimized_final_meth) {
     CFCType *return_type = CFCMethod_get_return_type(method);
     const char *ret_type_str = CFCType_to_c(return_type);
     const char *maybe_return = CFCType_is_void(return_type) ? "" : "return ";
+
+    // If the method is final and the class where it is declared final is in
+    // the same parcel as the invocant, we can optimize the call by resolving
+    // to the implementing function directly.
+    int optimized_final_meth = false;
+    if (CFCMethod_final(method)) {
+        CFCClass *ancestor = klass;
+        while (ancestor && !CFCMethod_is_fresh(method, ancestor)) {
+            ancestor = CFCClass_get_parent(ancestor);
+        }
+        if (CFCClass_in_same_parcel(ancestor, klass)) {
+            optimized_final_meth = true;
+        }
+    }
 
     const char innards_pattern[] =
         "    const %s method = (%s)cfish_obj_method(%s, %s);\n"

--- a/compiler/src/CFCBindSpecs.c
+++ b/compiler/src/CFCBindSpecs.c
@@ -160,7 +160,7 @@ CFCBindSpecs_add_class(CFCBindSpecs *self, CFCClass *klass) {
         parent_ptr = CFCUtil_strdup("NULL");
     }
     else {
-        if (CFCClass_get_parcel(klass) == CFCClass_get_parcel(parent)) {
+        if (CFCClass_in_same_parcel(klass, parent)) {
             parent_ptr
                 = CFCUtil_sprintf("&%s", CFCClass_full_class_var(parent));
         }
@@ -379,7 +379,7 @@ S_parent_offset(CFCBindSpecs *self, CFCMethod *method, CFCClass *klass,
     char *parent_offset = NULL;
     char *parent_offset_sym = CFCMethod_full_offset_sym(method, parent);
 
-    if (CFCClass_get_parcel(parent) == CFCClass_get_parcel(klass)) {
+    if (CFCClass_in_same_parcel(klass, parent)) {
         parent_offset = CFCUtil_sprintf("&%s", parent_offset_sym);
     }
     else {

--- a/compiler/src/CFCCHtml.c
+++ b/compiler/src/CFCCHtml.c
@@ -1071,19 +1071,15 @@ S_type_to_html(CFCType *type, const char *sep, CFCClass *doc_class) {
     char *specifier_html = NULL;
 
     if (CFCType_is_object(type)) {
-        CFCClass   *klass = NULL;
-
-        // Don't link to doc class.
-        if (strcmp(specifier, CFCClass_full_struct_sym(doc_class)) != 0) {
-            klass = CFCClass_fetch_by_struct_sym(specifier);
-            if (!klass) {
-                CFCUtil_warn("Class '%s' not found", specifier);
-            }
-            else if (!CFCClass_public(klass)) {
-                CFCUtil_warn("Non-public class '%s' used in public method",
-                             specifier);
-                klass = NULL;
-            }
+        CFCClass *klass = CFCType_get_class(type);
+        if (klass == doc_class) {
+            // Don't link to doc class.
+            klass = NULL;
+        }
+        else if (!CFCClass_public(klass)) {
+            CFCUtil_warn("Non-public class '%s' used in public method",
+                         specifier);
+            klass = NULL;
         }
 
         const char *underscore = strchr(specifier, '_');

--- a/compiler/src/CFCCallable.c
+++ b/compiler/src/CFCCallable.c
@@ -91,11 +91,6 @@ CFCCallable_get_param_list(CFCCallable *self) {
     return self->param_list;
 }
 
-CFCDocuComment*
-CFCCallable_get_docucomment(CFCCallable *self) {
-    return self->docucomment;
-}
-
 const char*
 CFCCallable_get_name(CFCCallable *self) {
     return CFCSymbol_get_name((CFCSymbol*)self);

--- a/compiler/src/CFCCallable.h
+++ b/compiler/src/CFCCallable.h
@@ -76,9 +76,6 @@ CFCCallable_get_return_type(CFCCallable *self);
 struct CFCParamList*
 CFCCallable_get_param_list(CFCCallable *self);
 
-struct CFCDocuComment*
-CFCCallable_get_docucomment(CFCCallable *self);
-
 const char*
 CFCCallable_get_name(CFCCallable *self);
 

--- a/compiler/src/CFCClass.c
+++ b/compiler/src/CFCClass.c
@@ -864,13 +864,6 @@ CFCClass_abstract(CFCClass *self) {
 }
 
 int
-CFCClass_needs_documentation(CFCClass *self) {
-    return CFCClass_public(self)
-           && !CFCClass_included(self)
-           && CFCParcel_is_installed(self->parcel);
-}
-
-int
 CFCClass_in_parcel(CFCClass *self, struct CFCParcel *parcel) {
     return CFCClass_get_parcel(self) == parcel;
 }

--- a/compiler/src/CFCClass.c
+++ b/compiler/src/CFCClass.c
@@ -655,15 +655,6 @@ S_establish_ancestry(CFCClass *self) {
     }
 }
 
-static size_t
-S_family_tree_size(CFCClass *self) {
-    size_t count = 1; // self
-    for (size_t i = 0; i < self->num_kids; i++) {
-        count += S_family_tree_size(self->children[i]);
-    }
-    return count;
-}
-
 static CFCBase**
 S_copy_cfcbase_array(CFCBase **array, size_t num_elems) {
     CFCBase **copy = (CFCBase**)MALLOCATE((num_elems + 1) * sizeof(CFCBase*));
@@ -698,26 +689,6 @@ CFCClass_grow_tree(CFCClass *self) {
     S_bequeath_methods(self);
 
     self->tree_grown = 1;
-}
-
-// Return value is valid only so long as object persists (elements are not
-// refcounted).
-CFCClass**
-CFCClass_tree_to_ladder(CFCClass *self) {
-    size_t ladder_len = S_family_tree_size(self);
-    CFCClass **ladder = (CFCClass**)MALLOCATE((ladder_len + 1) * sizeof(CFCClass*));
-    ladder[ladder_len] = NULL;
-    size_t step = 0;
-    ladder[step++] = self;
-    for (size_t i = 0; i < self->num_kids; i++) {
-        CFCClass *child = self->children[i];
-        CFCClass **child_ladder = CFCClass_tree_to_ladder(child);
-        for (size_t j = 0; child_ladder[j] != NULL; j++) {
-            ladder[step++] = child_ladder[j];
-        }
-        FREEMEM(child_ladder);
-    }
-    return ladder;
 }
 
 void

--- a/compiler/src/CFCClass.c
+++ b/compiler/src/CFCClass.c
@@ -239,7 +239,7 @@ CFCClass_do_create(CFCClass *self, struct CFCParcel *parcel,
 
     // Cache several derived symbols.
 
-    const char *prefix = CFCClass_get_prefix(self);
+    const char *prefix = CFCParcel_get_prefix(parcel);
     self->struct_sym        = CFCUtil_strdup(struct_sym);
     self->full_struct_sym   = CFCUtil_sprintf("%s%s", prefix, struct_sym);
     self->ivars_struct      = CFCUtil_sprintf("%sIVARS", struct_sym);
@@ -251,7 +251,7 @@ CFCClass_do_create(CFCClass *self, struct CFCParcel *parcel,
     self->full_ivars_offset = CFCUtil_sprintf("%s_OFFSET",
                                               self->full_ivars_func);
 
-    const char *PREFIX = CFCClass_get_PREFIX(self);
+    const char *PREFIX = CFCParcel_get_PREFIX(parcel);
     size_t struct_sym_len = strlen(struct_sym);
     char *short_class_var = (char*)MALLOCATE(struct_sym_len + 1);
     size_t i;
@@ -663,11 +663,10 @@ CFCClass_num_member_vars(CFCClass *self) {
 // outside this package.
 size_t
 CFCClass_num_non_package_ivars(CFCClass *self) {
-    CFCParcel *parcel       = CFCClass_get_parcel(self);
     CFCClass  *ancestor     = CFCClass_get_parent(self);
     size_t num_non_package_members = 0;
 
-    while (ancestor && CFCClass_get_parcel(ancestor) == parcel) {
+    while (ancestor && CFCClass_in_same_parcel(ancestor, self)) {
         ancestor = CFCClass_get_parent(ancestor);
     }
     if (ancestor) {

--- a/compiler/src/CFCClass.c
+++ b/compiler/src/CFCClass.c
@@ -363,11 +363,6 @@ CFCClass_add_child(CFCClass *self, CFCClass *child) {
 
     // Set parent of child.
     CFCWeakPtr_set(&child->parent, (CFCBase*)self);
-
-    // Add parcel dependency.
-    CFCParcel *parcel       = CFCClass_get_parcel(self);
-    CFCParcel *child_parcel = CFCClass_get_parcel(child);
-    CFCParcel_add_inherited_parcel(child_parcel, parcel);
 }
 
 void

--- a/compiler/src/CFCClass.c
+++ b/compiler/src/CFCClass.c
@@ -885,6 +885,16 @@ CFCClass_needs_documentation(CFCClass *self) {
            && CFCParcel_is_installed(self->parcel);
 }
 
+int
+CFCClass_in_parcel(CFCClass *self, struct CFCParcel *parcel) {
+    return CFCClass_get_parcel(self) == parcel;
+}
+
+int
+CFCClass_in_same_parcel(CFCClass *self, CFCClass *other) {
+    return CFCClass_get_parcel(self) == CFCClass_get_parcel(other);
+}
+
 const char*
 CFCClass_get_struct_sym(CFCClass *self) {
     return self->struct_sym;

--- a/compiler/src/CFCClass.c
+++ b/compiler/src/CFCClass.c
@@ -300,6 +300,7 @@ CFCClass_do_create(CFCClass *self, struct CFCParcel *parcel,
     CFCUTIL_TRY {
         // Store in registry.
         S_register(self);
+        CFCParcel_add_class(parcel, self);
     }
     CFCUTIL_CATCH(error);
 
@@ -307,8 +308,6 @@ CFCClass_do_create(CFCClass *self, struct CFCParcel *parcel,
         CFCBase_decref((CFCBase*)self);
         CFCUtil_rethrow(error);
     }
-
-    CFCParcel_add_struct_sym(parcel, self->struct_sym);
 
     return self;
 }
@@ -367,27 +366,13 @@ S_register(CFCClass *self) {
         registry_cap = new_cap;
     }
 
-    const char *prefix     = CFCParcel_get_prefix(self->parcel);
-    const char *name       = self->name;
-    const char *nickname   = self->nickname;
-    const char *struct_sym = self->full_struct_sym;
+    const char *name = self->name;
 
     for (size_t i = 0; i < registry_size; i++) {
-        CFCClass   *other        = registry[i];
-        const char *other_prefix = CFCParcel_get_prefix(other->parcel);
+        CFCClass *other = registry[i];
 
         if (strcmp(name, other->name) == 0) {
             CFCUtil_die("Two classes with name %s", name);
-        }
-        if (strcmp(struct_sym, other->full_struct_sym) == 0) {
-            CFCUtil_die("Class name conflict between %s and %s",
-                        name, other->name);
-        }
-        if (strcmp(prefix, other_prefix) == 0
-            && strcmp(nickname, other->nickname) == 0
-           ) {
-            CFCUtil_die("Class nickname conflict between %s and %s",
-                        name, other->name);
         }
     }
 

--- a/compiler/src/CFCClass.h
+++ b/compiler/src/CFCClass.h
@@ -258,6 +258,12 @@ CFCClass_abstract(CFCClass *self);
 int
 CFCClass_needs_documentation(CFCClass *self);
 
+int
+CFCClass_in_parcel(CFCClass *self, struct CFCParcel *parcel);
+
+int
+CFCClass_in_same_parcel(CFCClass *self, CFCClass *other);
+
 const char*
 CFCClass_get_struct_sym(CFCClass *self);
 

--- a/compiler/src/CFCClass.h
+++ b/compiler/src/CFCClass.h
@@ -200,11 +200,6 @@ CFCClass_inert_vars(CFCClass *self);
 const char*
 CFCClass_get_nickname(CFCClass *self);
 
-/** Set the parent Class. (Not class name, Class.)
- */
-void
-CFCClass_set_parent(CFCClass *self, CFCClass *parent);
-
 CFCClass*
 CFCClass_get_parent(CFCClass *self);
 

--- a/compiler/src/CFCClass.h
+++ b/compiler/src/CFCClass.h
@@ -87,26 +87,6 @@ CFCClass_do_create(CFCClass *self, struct CFCParcel *parcel,
 void
 CFCClass_destroy(CFCClass *self);
 
-/** Retrieve a Class, if one has already been created.
- *
- * @param class_name The name of the Class.
- */
-CFCClass*
-CFCClass_fetch_singleton(const char *class_name);
-
-/** Retrieve a Class by its struct sym.
- *
- * @param full_struct_sym The Class's full struct sym.
- */
-CFCClass*
-CFCClass_fetch_by_struct_sym(const char *full_struct_sym);
-
-/** Empty out the registry, decrementing the refcount of all Class singleton
- * objects.
- */
-void
-CFCClass_clear_registry(void);
-
 /** Add a child class.
  */
 void

--- a/compiler/src/CFCClass.h
+++ b/compiler/src/CFCClass.h
@@ -162,12 +162,6 @@ CFCClass_resolve_types(CFCClass *self);
 void
 CFCClass_grow_tree(CFCClass *self);
 
-/** Return this class and all its child classes as an array, where all
- * children appear after their parent nodes.
- */
-CFCClass**
-CFCClass_tree_to_ladder(CFCClass *self);
-
 /** Read host-specific data for the class from a JSON hash.
  */
 void

--- a/compiler/src/CFCClass.h
+++ b/compiler/src/CFCClass.h
@@ -256,9 +256,6 @@ int
 CFCClass_abstract(CFCClass *self);
 
 int
-CFCClass_needs_documentation(CFCClass *self);
-
-int
 CFCClass_in_parcel(CFCClass *self, struct CFCParcel *parcel);
 
 int

--- a/compiler/src/CFCGo.c
+++ b/compiler/src/CFCGo.c
@@ -238,7 +238,7 @@ S_gen_autogen_go(CFCGo *self, CFCParcel *parcel) {
         CFCGoClass *class_binding = registry[i];
         CFCClass *client = CFCGoClass_get_client(class_binding);
 
-        if (CFCClass_get_parcel(client) != parcel) {
+        if (!CFCClass_in_parcel(client, parcel)) {
             continue;
         }
 

--- a/compiler/src/CFCGo.c
+++ b/compiler/src/CFCGo.c
@@ -143,8 +143,8 @@ S_write_hostdefs(CFCGo *self) {
 
 // Pound-includes for generated headers.
 static char*
-S_gen_h_includes(CFCGo *self) {
-    CFCClass **ordered = CFCHierarchy_ordered_classes(self->hierarchy);
+S_gen_h_includes(CFCParcel *parcel) {
+    CFCClass **ordered = CFCParcel_get_classes(parcel);
     char *h_includes = CFCUtil_strdup("");
     for (size_t i = 0; ordered[i] != NULL; i++) {
         CFCClass *klass = ordered[i];
@@ -152,20 +152,14 @@ S_gen_h_includes(CFCGo *self) {
         h_includes = CFCUtil_cat(h_includes, "#include \"", include_h,
                                    "\"\n", NULL);
     }
-    FREEMEM(ordered);
     return h_includes;
 }
 
 static void
-S_register_classes(CFCGo *self, CFCParcel *parcel) {
-    CFCClass **ordered = CFCHierarchy_ordered_classes(self->hierarchy);
+S_register_classes(CFCParcel *parcel) {
+    CFCClass **ordered = CFCParcel_get_classes(parcel);
     for (size_t i = 0; ordered[i] != NULL; i++) {
         CFCClass *klass = ordered[i];
-        if (CFCClass_included(klass)
-            || CFCClass_get_parcel(klass) != parcel
-           ) {
-            continue;
-        }
         const char *class_name = CFCClass_get_name(klass);
         if (!CFCGoClass_singleton(class_name)) {
             CFCGoClass *binding = CFCGoClass_new(parcel, class_name);
@@ -365,9 +359,9 @@ S_write_cfbind_go(CFCGo *self, CFCParcel *parcel, const char *dest,
 
 void
 CFCGo_write_bindings(CFCGo *self, CFCParcel *parcel, const char *dest) {
-    char *h_includes = S_gen_h_includes(self);
+    char *h_includes = S_gen_h_includes(parcel);
 
-    S_register_classes(self, parcel);
+    S_register_classes(parcel);
     S_write_hostdefs(self);
     S_write_cfbind_go(self, parcel, dest, h_includes);
 

--- a/compiler/src/CFCGoClass.c
+++ b/compiler/src/CFCGoClass.c
@@ -72,8 +72,8 @@ CFCGoClass_new(CFCParcel *parcel, const char *class_name) {
     CFCGoClass *self = (CFCGoClass*)CFCBase_allocate(&CFCGOCLASS_META);
     self->parcel = (CFCParcel*)CFCBase_incref((CFCBase*)parcel);
     self->class_name = CFCUtil_strdup(class_name);
-    // Client may be NULL, since fetch_singleton() does not always succeed.
-    CFCClass *client = CFCClass_fetch_singleton(class_name);
+    // Client may be NULL, since class() does not always succeed.
+    CFCClass *client = CFCParcel_class(parcel, class_name);
     self->client = (CFCClass*)CFCBase_incref((CFCBase*)client);
     return self;
 }
@@ -133,7 +133,7 @@ CFCGoClass_singleton(const char *class_name) {
 CFCClass*
 CFCGoClass_get_client(CFCGoClass *self) {
     if (!self->client) {
-        CFCClass *client = CFCClass_fetch_singleton(self->class_name);
+        CFCClass *client = CFCParcel_class(self->parcel, self->class_name);
         self->client = (CFCClass*)CFCBase_incref((CFCBase*)client);
     }
     return self->client;

--- a/compiler/src/CFCGoClass.c
+++ b/compiler/src/CFCGoClass.c
@@ -281,7 +281,7 @@ CFCGoClass_gen_ctors(CFCGoClass *self) {
        ) {
         return CFCUtil_strdup("");
     }
-    CFCParcel    *parcel     = CFCClass_get_parcel(self->client);
+    CFCParcel    *parcel     = self->parcel;
     CFCParamList *param_list = CFCFunction_get_param_list(ctor_func);
     CFCType      *ret_type   = CFCFunction_get_return_type(ctor_func);
     const char   *struct_sym = CFCClass_get_struct_sym(self->client);

--- a/compiler/src/CFCGoTypeMap.c
+++ b/compiler/src/CFCGoTypeMap.c
@@ -24,6 +24,7 @@
 #include "CFCVariable.h"
 #include "CFCType.h"
 #include "CFCUtil.h"
+#include "CFCClass.h"
 
 #ifndef true
     #define true 1
@@ -109,32 +110,12 @@ CFCGoTypeMap_go_type_name(CFCType *type, CFCParcel *current_parcel) {
     }
     else if (CFCType_is_object(type)) {
         // Divide the specifier into prefix and struct name.
-        const char *specifier  = CFCType_get_specifier(type);
-        size_t      prefix_len = 0;
-        for (size_t max = strlen(specifier); prefix_len < max; prefix_len++) {
-            if (CFCUtil_isupper(specifier[prefix_len])) {
-                break;
-            }
-        }
-        if (!prefix_len) {
-            CFCUtil_die("Can't convert object type name '%s'", specifier);
-        }
-        const char *struct_sym = specifier + prefix_len;
-
-        // Find the parcel that the type lives in.
-        CFCParcel** all_parcels = CFCParcel_all_parcels();
-        CFCParcel *parcel = NULL;
-        for (int i = 0; all_parcels[i] != NULL; i++) {
-            const char *candidate = CFCParcel_get_prefix(all_parcels[i]);
-            if (strncmp(candidate, specifier, prefix_len) == 0
-                && strlen(candidate) == prefix_len
-               ) {
-                parcel = all_parcels[i];
-                break;
-            }
-        }
+        CFCClass   *klass      = CFCType_get_class(type);
+        const char *struct_sym = CFCClass_get_struct_sym(klass);
+        CFCParcel  *parcel     = CFCClass_get_parcel(klass);
         if (!parcel) {
-            CFCUtil_die("Can't find parcel for type '%s'", specifier);
+            CFCUtil_die("Can't find parcel for type '%s'",
+                        CFCType_get_specifier(type));
         }
 
         // If the type lives in this parcel, return only the struct sym

--- a/compiler/src/CFCHierarchy.c
+++ b/compiler/src/CFCHierarchy.c
@@ -232,12 +232,6 @@ CFCHierarchy_build(CFCHierarchy *self) {
         S_find_prereqs(self, source_parcels[i]);
     }
 
-    // Read .cfh and .md files.
-    for (size_t i = 0; self->sources[i] != NULL; i++) {
-        S_parse_cf_files(self, self->sources[i], false);
-        S_find_doc_files(self->sources[i]);
-    }
-
     // Read .cfh files of included parcels.
     parcels = CFCParcel_all_parcels();
     for (size_t i = 0; parcels[i] != NULL; i++) {
@@ -246,6 +240,12 @@ CFCHierarchy_build(CFCHierarchy *self) {
             const char *source_dir = CFCParcel_get_source_dir(parcel);
             S_parse_cf_files(self, source_dir, true);
         }
+    }
+
+    // Read .cfh and .md files of source parcels.
+    for (size_t i = 0; self->sources[i] != NULL; i++) {
+        S_parse_cf_files(self, self->sources[i], false);
+        S_find_doc_files(self->sources[i]);
     }
 
     for (int i = 0; self->classes[i] != NULL; i++) {
@@ -375,9 +375,11 @@ S_find_prereq(CFCHierarchy *self, CFCParcel *parent, CFCPrereq *prereq) {
                     CFCParcel_get_name(parent));
     }
 
-    CFCParcel_register(parcel);
-
+    // Make sure to register prereq parcels first, so that prereq
+    // parent classes precede subclasses.
     S_find_prereqs(self, parcel);
+
+    CFCParcel_register(parcel);
 
     CFCBase_decref((CFCBase*)parcel);
 }

--- a/compiler/src/CFCHierarchy.c
+++ b/compiler/src/CFCHierarchy.c
@@ -644,29 +644,6 @@ S_add_tree(CFCHierarchy *self, CFCClass *klass) {
     self->trees[self->num_trees] = NULL;
 }
 
-CFCClass**
-CFCHierarchy_ordered_classes(CFCHierarchy *self) {
-    size_t num_classes = 0;
-    size_t max_classes = 10;
-    CFCClass **ladder = (CFCClass**)MALLOCATE(
-                            (max_classes + 1) * sizeof(CFCClass*));
-    for (size_t i = 0; self->trees[i] != NULL; i++) {
-        CFCClass *tree = self->trees[i];
-        CFCClass **child_ladder = CFCClass_tree_to_ladder(tree);
-        for (size_t j = 0; child_ladder[j] != NULL; j++) {
-            if (num_classes == max_classes) {
-                max_classes += 10;
-                ladder = (CFCClass**)REALLOCATE(
-                             ladder, (max_classes + 1) * sizeof(CFCClass*));
-            }
-            ladder[num_classes++] = child_ladder[j];
-        }
-        FREEMEM(child_ladder);
-    }
-    ladder[num_classes] = NULL;
-    return ladder;
-}
-
 void
 CFCHierarchy_write_log(CFCHierarchy *self) {
     // For now, we only write an empty file that can be used as a Makefile

--- a/compiler/src/CFCHierarchy.c
+++ b/compiler/src/CFCHierarchy.c
@@ -256,6 +256,9 @@ CFCHierarchy_build(CFCHierarchy *self) {
     for (size_t i = 0; self->trees[i] != NULL; i++) {
         CFCClass_grow_tree(self->trees[i]);
     }
+    for (size_t i = 0; parcels[i] != NULL; i++) {
+        CFCParcel_sort_classes(parcels[i]);
+    }
 
     FREEMEM(source_parcels);
 }

--- a/compiler/src/CFCHierarchy.h
+++ b/compiler/src/CFCHierarchy.h
@@ -89,12 +89,6 @@ CFCHierarchy_propagate_modified(CFCHierarchy *self, int modified);
 void
 CFCHierarchy_write_log(CFCHierarchy *self);
 
-/** Return all Classes as an array with the property that every parent class
- * will precede all of its children.
- */
-struct CFCClass**
-CFCHierarchy_ordered_classes(CFCHierarchy *self);
-
 struct CFCFile**
 CFCHierarchy_files(CFCHierarchy *self);
 

--- a/compiler/src/CFCMethod.c
+++ b/compiler/src/CFCMethod.c
@@ -453,6 +453,29 @@ CFCMethod_short_imp_func(CFCMethod *self, CFCClass *klass) {
     return S_short_method_sym(self, klass, "_IMP");
 }
 
+CFCDocuComment*
+CFCMethod_get_docucomment(CFCMethod *self, CFCClass **class_ptr) {
+    CFCMethod  *method = self;
+    const char *name   = CFCMethod_get_name(self);
+
+    do {
+        CFCClass *klass = S_fresh_class(method);
+
+        CFCDocuComment *comment = method->callable.docucomment;
+        if (comment) {
+            if (class_ptr) { *class_ptr = klass; }
+            return comment;
+        }
+
+        CFCClass *parent = CFCClass_get_parent(klass);
+        if (!parent) { break; }
+        method = CFCClass_method(parent, name);
+    } while (method);
+
+    if (class_ptr) { *class_ptr = NULL; }
+    return NULL;
+}
+
 static CFCClass*
 S_fresh_class(CFCMethod *self) {
     return (CFCClass*)CFCWeakPtr_deref(self->fresh_class);

--- a/compiler/src/CFCMethod.h
+++ b/compiler/src/CFCMethod.h
@@ -231,6 +231,13 @@ CFCMethod_imp_func(CFCMethod *self, struct CFCClass *klass);
 char*
 CFCMethod_short_imp_func(CFCMethod *self, struct CFCClass *klass);
 
+/** Return the DocuComment for the method, which may be inherited. If
+ * `class_ptr` is non-NULL, use it to store the class where the comment
+ * found.
+ */
+struct CFCDocuComment*
+CFCMethod_get_docucomment(CFCMethod *self, struct CFCClass **class_ptr);
+
 #ifdef __cplusplus
 }
 #endif

--- a/compiler/src/CFCMethod.h
+++ b/compiler/src/CFCMethod.h
@@ -46,23 +46,22 @@ struct CFCJson;
  * method.
  * @param return_type See Clownfish::CFC::Model::Function.
  * @param param_list - A Clownfish::CFC::Model::ParamList.  The first element
- * must be an object of the class identified by C<class_name>.
+ * must be an object of C<klass>.
  * @param docucomment see Clownfish::CFC::Model::Function.  May be NULL.
- * @param class_name The full name of the class in whose namespace the
- * method is fresh.
+ * @param klass The class in whose namespace the method is fresh.
  * @param is_final - Indicate whether the method is final.
  * @param is_abstract - Indicate whether the method is abstract.
  */
 CFCMethod*
 CFCMethod_new(const char *exposure, const char *name,
               struct CFCType *return_type, struct CFCParamList *param_list,
-              struct CFCDocuComment *docucomment, const char *class_name,
+              struct CFCDocuComment *docucomment, struct CFCClass *klass,
               int is_final, int is_abstract);
 
 CFCMethod*
 CFCMethod_init(CFCMethod *self, const char *exposure, const char *name,
                struct CFCType *return_type, struct CFCParamList *param_list,
-               struct CFCDocuComment *docucomment, const char *class_name,
+               struct CFCDocuComment *docucomment, struct CFCClass *klass,
                int is_final, int is_abstract);
 
 void

--- a/compiler/src/CFCParcel.c
+++ b/compiler/src/CFCParcel.c
@@ -635,6 +635,9 @@ CFCParcel_connect_and_sort_classes(CFCParcel *self) {
             // Subtree root.
             sorted[--todo] = klass;
         }
+
+        // Resolve types.
+        CFCClass_resolve_types(klass);
     }
 
     qsort(&sorted[todo], num_classes - todo, sizeof(sorted[0]),

--- a/compiler/src/CFCParcel.c
+++ b/compiler/src/CFCParcel.c
@@ -427,6 +427,11 @@ CFCParcel_is_installed(CFCParcel *self) {
     return self->is_installed;
 }
 
+void
+CFCParcel_set_installed(CFCParcel *self, int is_installed) {
+    self->is_installed = is_installed;
+}
+
 CFCVersion*
 CFCParcel_get_version(CFCParcel *self) {
     return self->version;

--- a/compiler/src/CFCParcel.c
+++ b/compiler/src/CFCParcel.c
@@ -297,7 +297,9 @@ S_new_from_json(const char *json, CFCFileSpec *file_spec) {
     }
     CFCParcel *self = CFCParcel_new(name, nickname, version, major_version,
                                     file_spec);
-    self->is_installed = installed;
+    if (!file_spec || !CFCFileSpec_included(file_spec)) {
+        self->is_installed = installed;
+    }
     if (prereqs) {
         S_set_prereqs(self, prereqs, path);
     }

--- a/compiler/src/CFCParcel.c
+++ b/compiler/src/CFCParcel.c
@@ -44,8 +44,6 @@ struct CFCParcel {
     char *PREFIX;
     char *privacy_sym;
     int is_installed;
-    char **inherited_parcels;
-    size_t num_inherited_parcels;
     CFCClass **classes;
     size_t num_classes;
     CFCPrereq **prereqs;
@@ -215,8 +213,6 @@ CFCParcel_init(CFCParcel *self, const char *name, const char *nickname,
     self->is_installed = false;
 
     // Initialize arrays.
-    self->inherited_parcels = (char**)CALLOCATE(1, sizeof(char*));
-    self->num_inherited_parcels = 0;
     self->classes = (CFCClass**)CALLOCATE(1, sizeof(CFCClass*));
     self->num_classes = 0;
     self->prereqs = (CFCPrereq**)CALLOCATE(1, sizeof(CFCPrereq*));
@@ -372,7 +368,6 @@ CFCParcel_destroy(CFCParcel *self) {
     FREEMEM(self->Prefix);
     FREEMEM(self->PREFIX);
     FREEMEM(self->privacy_sym);
-    CFCUtil_free_string_array(self->inherited_parcels);
     for (size_t i = 0; self->classes[i]; ++i) {
         CFCBase_decref((CFCBase*)self->classes[i]);
     }
@@ -482,40 +477,6 @@ CFCParcel_get_source_dir(CFCParcel *self) {
 int
 CFCParcel_included(CFCParcel *self) {
     return self->file_spec ? CFCFileSpec_included(self->file_spec) : false;
-}
-
-void
-CFCParcel_add_inherited_parcel(CFCParcel *self, CFCParcel *inherited) {
-    const char *name     = CFCParcel_get_name(self);
-    const char *inh_name = CFCParcel_get_name(inherited);
-
-    if (strcmp(name, inh_name) == 0) { return; }
-
-    for (size_t i = 0; self->inherited_parcels[i]; ++i) {
-        const char *other_name = self->inherited_parcels[i];
-        if (strcmp(other_name, inh_name) == 0) { return; }
-    }
-
-    size_t num_parcels = self->num_inherited_parcels;
-    self->inherited_parcels
-        = (char**)REALLOCATE(self->inherited_parcels,
-                             (num_parcels + 2) * sizeof(char*));
-    self->inherited_parcels[num_parcels]   = CFCUtil_strdup(inh_name);
-    self->inherited_parcels[num_parcels+1] = NULL;
-    self->num_inherited_parcels = num_parcels + 1;
-}
-
-CFCParcel**
-CFCParcel_inherited_parcels(CFCParcel *self) {
-    CFCParcel **parcels
-        = (CFCParcel**)CALLOCATE(self->num_inherited_parcels + 1,
-                                 sizeof(CFCParcel*));
-
-    for (size_t i = 0; self->inherited_parcels[i]; ++i) {
-        parcels[i] = CFCParcel_fetch(self->inherited_parcels[i]);
-    }
-
-    return parcels;
 }
 
 CFCPrereq**

--- a/compiler/src/CFCParcel.h
+++ b/compiler/src/CFCParcel.h
@@ -146,18 +146,6 @@ CFCParcel_get_source_dir(CFCParcel *self);
 int
 CFCParcel_included(CFCParcel *self);
 
-/** Add another Parcel containing superclasses that subclasses in the Parcel
- * extend.
- */
-void
-CFCParcel_add_inherited_parcel(CFCParcel *self, CFCParcel *inherited);
-
-/** Return a NULL-terminated array of all Parcels containing superclasses that
- * subclasses in the Parcel extend. Must be freed by the caller.
- */
-CFCParcel**
-CFCParcel_inherited_parcels(CFCParcel *self);
-
 /** Return a NULL-terminated array of all prerequisites.
  */
 CFCPrereq**

--- a/compiler/src/CFCParcel.h
+++ b/compiler/src/CFCParcel.h
@@ -184,16 +184,29 @@ CFCParcel_add_class(CFCParcel *self, struct CFCClass *klass);
 void
 CFCParcel_sort_classes(CFCParcel *self);
 
+/** Search for a class by class name. Doesn't search prereqs. Returns
+ * NULL if no class was found.
+ */
+struct CFCClass*
+CFCParcel_class(CFCParcel *self, const char *class_name);
+
+/** Search for a class by short struct symbol. Searches direct prereqs.
+ * Returns NULL if no class was found. Throws an exception if the
+ * struct symbol doesn't match unambiguously.
+ */
+struct CFCClass*
+CFCParcel_class_by_short_sym(CFCParcel *self, const char *struct_sym);
+
+/** Search for a class by full struct symbol. Searches direct prereqs.
+ * Returns NULL if no class was found.
+ */
+struct CFCClass*
+CFCParcel_class_by_full_sym(CFCParcel *self, const char *full_struct_sym);
+
 /** Return the ordered list of classes in the parcel.
  */
 struct CFCClass**
 CFCParcel_get_classes(CFCParcel *self);
-
-/** Search the parcel and all direct prerequisites for a class with
- * struct_sym. Return the parcel in which the class was found or NULL.
- */
-CFCParcel*
-CFCParcel_lookup_struct_sym(CFCParcel *self, const char *struct_sym);
 
 /** Indicate whether the parcel is "clownfish", the main Clownfish runtime.
  */

--- a/compiler/src/CFCParcel.h
+++ b/compiler/src/CFCParcel.h
@@ -182,10 +182,11 @@ CFCParcel_read_host_data_json(CFCParcel *self, const char *host_lang);
 void
 CFCParcel_add_class(CFCParcel *self, struct CFCClass *klass);
 
-/** Sort parents before child classes.
+/** Set up parent/child relationship of classes and sort parents before
+ * child classes.
  */
 void
-CFCParcel_sort_classes(CFCParcel *self);
+CFCParcel_connect_and_sort_classes(CFCParcel *self);
 
 /** Search for a class by class name. Doesn't search prereqs. Returns
  * NULL if no class was found.

--- a/compiler/src/CFCParcel.h
+++ b/compiler/src/CFCParcel.h
@@ -179,6 +179,16 @@ CFCParcel_read_host_data_json(CFCParcel *self, const char *host_lang);
 void
 CFCParcel_add_class(CFCParcel *self, struct CFCClass *klass);
 
+/** Sort parents before child classes.
+ */
+void
+CFCParcel_sort_classes(CFCParcel *self);
+
+/** Return the ordered list of classes in the parcel.
+ */
+struct CFCClass**
+CFCParcel_get_classes(CFCParcel *self);
+
 /** Search the parcel and all direct prerequisites for a class with
  * struct_sym. Return the parcel in which the class was found or NULL.
  */

--- a/compiler/src/CFCParcel.h
+++ b/compiler/src/CFCParcel.h
@@ -100,6 +100,9 @@ CFCParcel_set_host_module_name(CFCParcel *self, const char *name);
 int
 CFCParcel_is_installed(CFCParcel *self);
 
+void
+CFCParcel_set_installed(CFCParcel *self, int is_installed);
+
 struct CFCVersion*
 CFCParcel_get_version(CFCParcel *self);
 

--- a/compiler/src/CFCParcel.h
+++ b/compiler/src/CFCParcel.h
@@ -38,6 +38,7 @@ extern "C" {
 
 typedef struct CFCParcel CFCParcel;
 typedef struct CFCPrereq CFCPrereq;
+struct CFCClass;
 struct CFCFileSpec;
 struct CFCVersion;
 
@@ -176,7 +177,7 @@ void
 CFCParcel_read_host_data_json(CFCParcel *self, const char *host_lang);
 
 void
-CFCParcel_add_struct_sym(CFCParcel *self, const char *struct_sym);
+CFCParcel_add_class(CFCParcel *self, struct CFCClass *klass);
 
 /** Search the parcel and all direct prerequisites for a class with
  * struct_sym. Return the parcel in which the class was found or NULL.

--- a/compiler/src/CFCParseHeader.y
+++ b/compiler/src/CFCParseHeader.y
@@ -113,9 +113,8 @@ S_new_sub(CFCParser *state, CFCDocuComment *docucomment,
             CFCUtil_die("Methods must not be inline");
         }
         CFCClass *klass = CFCParser_get_class(state);
-        const char *class_name = CFCClass_get_name(klass);
         sub = (CFCBase*)CFCMethod_new(exposure, name, type, param_list,
-                                      docucomment, class_name, is_final,
+                                      docucomment, klass, is_final,
                                       is_abstract);
     }
 

--- a/compiler/src/CFCParseHeader.y
+++ b/compiler/src/CFCParseHeader.y
@@ -49,12 +49,11 @@ S_start_class(CFCParser *state, CFCDocuComment *docucomment, char *exposure,
         is_inert = !!strstr(modifiers, "inert");
         is_abstract = !!strstr(modifiers, "abstract");
     }
-    CFCParser_set_class_name(state, class_name);
-    CFCParser_set_class_final(state, is_final);
     CFCClass *klass = CFCClass_create(CFCParser_get_parcel(state), exposure,
                                       class_name, class_nickname, docucomment,
                                       file_spec, inheritance, is_final,
                                       is_inert, is_abstract);
+    CFCParser_set_class(state, klass);
     CFCBase_decref((CFCBase*)docucomment);
     return klass;
 }
@@ -92,7 +91,8 @@ S_new_sub(CFCParser *state, CFCDocuComment *docucomment,
         is_inline   = !!strstr(modifiers, "inline");
         is_inert    = !!strstr(modifiers, "inert");
     }
-    if (CFCParser_get_class_final(state) && !is_inert) {
+    CFCClass *klass = CFCParser_get_class(state);
+    if (CFCClass_final(klass) && !is_inert) {
         is_final = true;
     }
 
@@ -112,7 +112,8 @@ S_new_sub(CFCParser *state, CFCDocuComment *docucomment,
         if (is_inline) {
             CFCUtil_die("Methods must not be inline");
         }
-        const char *class_name = CFCParser_get_class_name(state);
+        CFCClass *klass = CFCParser_get_class(state);
+        const char *class_name = CFCClass_get_name(klass);
         sub = (CFCBase*)CFCMethod_new(exposure, name, type, param_list,
                                       docucomment, class_name, is_final,
                                       is_abstract);
@@ -337,7 +338,7 @@ parcel_definition(A) ::= PARCEL qualified_id(B) SEMICOLON.
 class_declaration(A) ::= class_defs(B) RIGHT_CURLY_BRACE.
 {
     A = B;
-    CFCParser_set_class_name(state, NULL);
+    CFCParser_set_class(state, NULL);
 }
 
 class_head(A) ::= docucomment(B) exposure_specifier(C) declaration_modifier_list(D) CLASS qualified_id(E) nickname(F) class_inheritance(G).  { A = S_start_class(state, B,    C,    D,    E,    F,    G   ); }

--- a/compiler/src/CFCParser.c
+++ b/compiler/src/CFCParser.c
@@ -20,6 +20,7 @@
 #define CFC_NEED_BASE_STRUCT_DEF
 #include "CFCBase.h"
 #include "CFCParser.h"
+#include "CFCClass.h"
 #include "CFCParcel.h"
 #include "CFCFile.h"
 #include "CFCFileSpec.h"
@@ -39,8 +40,7 @@ struct CFCParser {
     struct CFCBase *result;
     int errors;
     int lineno;
-    char *class_name;
-    int class_is_final;
+    CFCClass *klass;
     CFCFileSpec *file_spec;
     CFCMemPool *pool;
     CFCParcel  *parcel;
@@ -67,7 +67,7 @@ CFCParser_init(CFCParser *self) {
     self->result         = NULL;
     self->errors         = false;
     self->lineno         = 0;
-    self->class_name     = NULL;
+    self->klass          = NULL;
     self->file_spec      = NULL;
     self->pool           = NULL;
     self->parcel         = NULL;
@@ -77,7 +77,7 @@ CFCParser_init(CFCParser *self) {
 void
 CFCParser_destroy(CFCParser *self) {
     CFCParseHeaderFree(self->header_parser, free);
-    FREEMEM(self->class_name);
+    CFCBase_decref((CFCBase*)self->klass);
     CFCBase_decref((CFCBase*)self->file_spec);
     CFCBase_decref((CFCBase*)self->pool);
     CFCBase_decref(self->result);
@@ -176,29 +176,15 @@ CFCParser_get_parcel(CFCParser *self) {
 }
 
 void
-CFCParser_set_class_name(CFCParser *self, const char *class_name) {
-    FREEMEM(self->class_name);
-    if (class_name) {
-        self->class_name = CFCUtil_strdup(class_name);
-    }
-    else {
-        self->class_name = NULL;
-    }
+CFCParser_set_class(CFCParser *self, CFCClass *klass) {
+    CFCBase_incref((CFCBase*)klass);
+    CFCBase_decref((CFCBase*)self->klass);
+    self->klass = klass;
 }
 
-const char*
-CFCParser_get_class_name(CFCParser *self) {
-    return self->class_name;
-}
-
-void
-CFCParser_set_class_final(CFCParser *self, int is_final) {
-    self->class_is_final = is_final;
-}
-
-int
-CFCParser_get_class_final(CFCParser *self) {
-    return self->class_is_final;
+CFCClass*
+CFCParser_get_class(CFCParser *self) {
+    return self->klass;
 }
 
 void

--- a/compiler/src/CFCParser.h
+++ b/compiler/src/CFCParser.h
@@ -30,6 +30,7 @@ extern "C" {
 
 typedef struct CFCParser CFCParser;
 struct CFCBase;
+struct CFCClass;
 struct CFCParcel;
 struct CFCFile;
 struct CFCFileSpec;
@@ -83,16 +84,10 @@ struct CFCParcel*
 CFCParser_get_parcel(CFCParser *self);
 
 void
-CFCParser_set_class_name(CFCParser *self, const char *class_name);
+CFCParser_set_class(CFCParser *self, struct CFCClass *klass);
 
-const char*
-CFCParser_get_class_name(CFCParser *self);
-
-void
-CFCParser_set_class_final(CFCParser *self, int is_final);
-
-int
-CFCParser_get_class_final(CFCParser *self);
+struct CFCClass*
+CFCParser_get_class(CFCParser *self);
 
 void
 CFCParser_set_file_spec(CFCParser *self, struct CFCFileSpec *file_spec);

--- a/compiler/src/CFCPerlPod.h
+++ b/compiler/src/CFCPerlPod.h
@@ -27,6 +27,7 @@ extern "C" {
 typedef struct CFCPerlPod CFCPerlPod;
 struct CFCCallable;
 struct CFCClass;
+struct CFCDocuComment;
 
 CFCPerlPod*
 CFCPerlPod_new(void);
@@ -128,12 +129,15 @@ CFCPerlPod_md_to_pod(const char *md, struct CFCClass *klass, int header_level);
  * @param code_sample Optional example usage code.
  * @param is_construtor Indicate whether this is a constructor, as the default
  * argument handling is different for constructors.
+ * @param docucomment An optional docucomment.
+ * @param base_class The class to resolve relative URIs in the docucomment.
  */
 char*
 CFCPerlPod_gen_subroutine_pod(struct CFCCallable *func,
                               const char *alias, struct CFCClass *klass,
-                              const char *code_sample,
-                              const char *class_name, int is_constructor);
+                              const char *code_sample, int is_constructor,
+                              struct CFCDocuComment *docucomment,
+                              struct CFCClass *base_class);
 
 #ifdef __cplusplus
 }

--- a/compiler/src/CFCPerlTypeMap.c
+++ b/compiler/src/CFCPerlTypeMap.c
@@ -41,8 +41,9 @@ CFCPerlTypeMap_from_perl(CFCType *type, const char *xs_var,
     char *result = NULL;
 
     if (CFCType_is_object(type)) {
-        const char *struct_sym   = CFCType_get_specifier(type);
-        const char *class_var    = CFCType_get_class_var(type);
+        CFCClass *klass = CFCType_get_class(type);
+        const char *struct_sym   = CFCClass_full_struct_sym(klass);
+        const char *class_var    = CFCClass_full_class_var(klass);
         const char *nullable_str = CFCType_nullable(type) ? "_nullable" : "";
         const char *allocation;
         if (strcmp(struct_sym, "cfish_String") == 0

--- a/compiler/src/CFCPyMethod.c
+++ b/compiler/src/CFCPyMethod.c
@@ -113,7 +113,8 @@ S_gen_declaration(CFCVariable *var, const char *val) {
             if (strcmp(specifier, "cfish_Hash") != 0
                 && strcmp(specifier, "cfish_Vector") != 0
                 ) {
-                const char *class_var = CFCType_get_class_var(type);
+                CFCClass *klass = CFCType_get_class(type);
+                const char *class_var = CFCClass_full_class_var(klass);
                 char pattern[] =
                     "    CFBindArg wrap_arg_%s = {%s, &%s_ARG};\n"
                     ;
@@ -262,9 +263,10 @@ S_build_pymeth_invocation(CFCMethod *method) {
         invocation = CFCUtil_sprintf(pattern, micro_sym);
     }
     else if (CFCType_is_object(return_type)) {
+        CFCClass *klass = CFCType_get_class(return_type);
+        const char *ret_class = CFCClass_full_class_var(klass);
         const char *nullable
             = CFCType_nullable(return_type) ? "true" : "false";
-        const char *ret_class = CFCType_get_class_var(return_type);
         const char pattern[] =
             "    %s cfcb_RESULT = (%s)CALL_PYMETH_OBJ((PyObject*)self, \"%s\", cfcb_ARGS, %s, %s);";
         invocation = CFCUtil_sprintf(pattern, ret_type_str, ret_type_str, micro_sym,

--- a/compiler/src/CFCRuby.c
+++ b/compiler/src/CFCRuby.c
@@ -171,13 +171,12 @@ S_write_boot_h(CFCRuby *self) {
 
 static void
 S_write_boot_c(CFCRuby *self) {
-    CFCClass **ordered   = CFCHierarchy_ordered_classes(self->hierarchy);
+    CFCClass **ordered   = CFCParcel_get_classes(self->parcel);
     char *pound_includes = CFCUtil_strdup("");
     const char *prefix   = CFCParcel_get_prefix(self->parcel);
 
     for (size_t i = 0; ordered[i] != NULL; i++) {
         CFCClass *klass = ordered[i];
-        if (CFCClass_included(klass)) { continue; }
 
         const char *include_h  = CFCClass_include_h(klass);
         pound_includes = CFCUtil_cat(pound_includes, "#include \"",
@@ -219,7 +218,6 @@ S_write_boot_c(CFCRuby *self) {
 
     FREEMEM(content);
     FREEMEM(pound_includes);
-    FREEMEM(ordered);
 }
 
 void

--- a/compiler/src/CFCTestClass.c
+++ b/compiler/src/CFCTestClass.c
@@ -105,8 +105,8 @@ S_run_tests(CFCTest *test) {
     CFCClass_add_inert_var(foo, widget);
 
     {
-        CFCClass *should_be_foo = CFCClass_fetch_singleton("Foo");
-        OK(test, should_be_foo == foo, "fetch_singleton");
+        CFCClass *should_be_foo = CFCParcel_class(neato, "Foo");
+        OK(test, should_be_foo == foo, "Fetch class from parcel");
     }
 
     {

--- a/compiler/src/CFCTestClass.c
+++ b/compiler/src/CFCTestClass.c
@@ -449,7 +449,6 @@ S_run_tests(CFCTest *test) {
     CFCBase_decref((CFCBase*)inert_foo);
     CFCBase_decref((CFCBase*)do_stuff);
 
-    CFCClass_clear_registry();
     CFCParcel_reap_singletons();
 }
 

--- a/compiler/src/CFCTestClass.c
+++ b/compiler/src/CFCTestClass.c
@@ -44,7 +44,7 @@ S_has_symbol(CFCSymbol **symbols, const char *name);
 
 const CFCTestBatch CFCTEST_BATCH_CLASS = {
     "Clownfish::CFC::Model::Class",
-    97,
+    93,
     S_run_tests
 };
 
@@ -308,15 +308,6 @@ S_run_tests(CFCTest *test) {
     {
         CFCMethod **fresh_methods = CFCClass_fresh_methods(final_foo);
         OK(test, fresh_methods[0] == NULL, "fresh_methods[0]");
-    }
-
-    {
-        CFCClass **ladder = CFCClass_tree_to_ladder(foo);
-        OK(test, ladder[0] == foo, "ladder[0]");
-        OK(test, ladder[1] == foo_jr, "ladder[1]");
-        OK(test, ladder[2] == final_foo, "ladder[2]");
-        OK(test, ladder[3] == NULL, "ladder[3]");
-        FREEMEM(ladder);
     }
 
     {

--- a/compiler/src/CFCTestClass.c
+++ b/compiler/src/CFCTestClass.c
@@ -156,7 +156,7 @@ S_run_tests(CFCTest *test) {
     }
 
     CFCParser_set_parcel(parser, neato);
-    CFCParser_set_class_name(parser, "Foo");
+    CFCParser_set_class(parser, foo);
     CFCMethod *do_stuff
         = CFCTest_parse_method(test, parser, "void Do_Stuff(Foo *self);");
     CFCClass_add_method(foo, do_stuff);
@@ -166,7 +166,7 @@ S_run_tests(CFCTest *test) {
                           false, true, false);
 
     {
-        CFCParser_set_class_name(parser, "InertFoo");
+        CFCParser_set_class(parser, inert_foo);
         CFCMethod *inert_do_stuff
             = CFCTest_parse_method(test, parser,
                                    "void Do_Stuff(InertFoo *self);");

--- a/compiler/src/CFCTestFile.c
+++ b/compiler/src/CFCTestFile.c
@@ -119,8 +119,6 @@ S_run_tests(CFCTest *test) {
         OK(test, blocks[4] == NULL, "blocks[4]");
 
         CFCBase_decref((CFCBase*)file);
-
-        CFCClass_clear_registry();
     }
 
     CFCBase_decref((CFCBase*)file_spec);

--- a/compiler/src/CFCTestFunction.c
+++ b/compiler/src/CFCTestFunction.c
@@ -18,6 +18,7 @@
 
 #define CFC_USE_TEST_MACROS
 #include "CFCBase.h"
+#include "CFCClass.h"
 #include "CFCFunction.h"
 #include "CFCParamList.h"
 #include "CFCParcel.h"
@@ -25,6 +26,11 @@
 #include "CFCTest.h"
 #include "CFCType.h"
 #include "CFCUtil.h"
+
+#ifndef true
+  #define true 1
+  #define false 0
+#endif
 
 static void
 S_run_tests(CFCTest *test);
@@ -68,7 +74,10 @@ S_run_tests(CFCTest *test) {
     }
 
     {
-        CFCParser_set_class_name(parser, "Neato::Obj");
+        CFCClass *neato_obj
+            = CFCClass_create(neato_parcel, NULL, "Neato::Obj", NULL, NULL,
+                              NULL, NULL, false, false, false);
+        CFCParser_set_class(parser, neato_obj);
         static const char *func_strings[2] = {
             "inert int running_count(int biscuit);",
             "public inert Hash* init_fave_hash(int32_t num_buckets,"
@@ -79,6 +88,7 @@ S_run_tests(CFCTest *test) {
                 = CFCTest_parse_function(test, parser, func_strings[i]);
             CFCBase_decref((CFCBase*)func);
         }
+        CFCBase_decref((CFCBase*)neato_obj);
     }
 
     CFCBase_decref((CFCBase*)return_type);

--- a/compiler/src/CFCTestHierarchy.c
+++ b/compiler/src/CFCTestHierarchy.c
@@ -165,7 +165,6 @@ S_run_basic_tests(CFCTest *test) {
 
     CFCBase_decref((CFCBase*)hierarchy);
     FREEMEM(cfbase_path);
-    CFCClass_clear_registry();
     CFCParcel_reap_singletons();
 }
 
@@ -210,7 +209,6 @@ S_run_include_tests(CFCTest *test) {
         OK(test, all_included, "All classes included");
 
         CFCBase_decref((CFCBase*)hierarchy);
-        CFCClass_clear_registry();
         CFCParcel_reap_singletons();
     }
 
@@ -248,7 +246,6 @@ S_run_include_tests(CFCTest *test) {
         OK(test, all_not_included, "All classes not included");
 
         CFCBase_decref((CFCBase*)hierarchy);
-        CFCClass_clear_registry();
         CFCParcel_reap_singletons();
     }
 
@@ -286,7 +283,6 @@ S_run_clash_tests(CFCTest *test) {
            "source/source filename clash");
 
         CFCBase_decref((CFCBase*)hierarchy);
-        CFCClass_clear_registry();
         CFCParcel_reap_singletons();
     }
 
@@ -307,7 +303,6 @@ S_run_clash_tests(CFCTest *test) {
            "source/include class name clash");
 
         CFCBase_decref((CFCBase*)hierarchy);
-        CFCClass_clear_registry();
         CFCParcel_reap_singletons();
     }
 
@@ -330,7 +325,6 @@ S_run_clash_tests(CFCTest *test) {
            "source class with included parcel");
 
         CFCBase_decref((CFCBase*)hierarchy);
-        CFCClass_clear_registry();
         CFCParcel_reap_singletons();
     }
 

--- a/compiler/src/CFCTestHierarchy.c
+++ b/compiler/src/CFCTestHierarchy.c
@@ -55,7 +55,7 @@ S_run_clash_tests(CFCTest *test);
 
 const CFCTestBatch CFCTEST_BATCH_HIERARCHY = {
     "Clownfish::CFC::Model::Hierarchy",
-    41,
+    42,
     S_run_tests
 };
 
@@ -115,13 +115,18 @@ S_run_basic_tests(CFCTest *test) {
     OK(test, files[3] == NULL, "recursed and found all three files");
 
     {
-        CFCClass **ordered_classes = CFCHierarchy_ordered_classes(hierarchy);
-        OK(test, ordered_classes[0] != NULL, "ordered_classes[0]");
-        OK(test, ordered_classes[1] != NULL, "ordered_classes[1]");
-        OK(test, ordered_classes[2] != NULL, "ordered_classes[2]");
-        OK(test, ordered_classes[3] != NULL, "ordered_classes[3]");
-        OK(test, ordered_classes[4] == NULL, "all classes");
-        FREEMEM(ordered_classes);
+        CFCParcel *parcel = CFCParcel_fetch("Animal");
+        OK(test, parcel != NULL, "Fetch parcel Animal");
+        CFCClass **classes = CFCParcel_get_classes(parcel);
+        STR_EQ(test, CFCClass_get_name(classes[0]), "Animal::Util",
+               "classes[0]");
+        STR_EQ(test, CFCClass_get_name(classes[1]), "Clownfish::Obj",
+               "classes[1]");
+        STR_EQ(test, CFCClass_get_name(classes[2]), "Animal",
+               "classes[2]");
+        STR_EQ(test, CFCClass_get_name(classes[3]), "Animal::Dog",
+               "classes[3]");
+        OK(test, classes[4] == NULL, "all classes");
     }
 
     // Generate fake C files, with times set to two seconds ago.
@@ -180,28 +185,30 @@ S_run_include_tests(CFCTest *test) {
 
         CFCHierarchy_build(hierarchy);
 
-        CFCClass **classes    = CFCHierarchy_ordered_classes(hierarchy);
-        CFCClass  *rottweiler = NULL;;
-        int num_classes;
-        int num_source_classes = 0;
-        for (num_classes = 0; classes[num_classes]; ++num_classes) {
-            CFCClass *klass = classes[num_classes];
-            int expect_included = 1;
-            const char *class_name = CFCClass_get_name(klass);
-            if (strcmp(class_name, "Animal::Rottweiler") == 0) {
-                rottweiler      = klass;
-                expect_included = 0;
-                ++num_source_classes;
-            }
-            INT_EQ(test, CFCClass_included(klass), expect_included,
-                   "included");
-        }
-        INT_EQ(test, num_classes, 5, "class count");
-        INT_EQ(test, num_source_classes, 1, "source class count");
-        STR_EQ(test, CFCClass_get_name(CFCClass_get_parent(rottweiler)),
-               "Animal::Dog", "parent of included class");
+        CFCParcel *parcel;
+        CFCClass **classes;
 
-        FREEMEM(classes);
+        parcel = CFCParcel_fetch("AnimalExtension");
+        OK(test, parcel != NULL, "Fetch parcel AnimalExtension");
+        classes = CFCParcel_get_classes(parcel);
+        STR_EQ(test, CFCClass_get_name(classes[0]), "Animal::Rottweiler",
+               "classes[0]");
+        OK(test, !CFCClass_included(classes[0]), "not included");
+        OK(test, classes[1] == NULL, "classes[1]");
+        STR_EQ(test, CFCClass_get_name(CFCClass_get_parent(classes[0])),
+               "Animal::Dog", "parent from different parcel");
+
+        parcel = CFCParcel_fetch("Animal");
+        OK(test, parcel != NULL, "Fetch parcel Animal");
+        classes = CFCParcel_get_classes(parcel);
+        int all_included = 1;
+        int num_classes;
+        for (num_classes = 0; classes[num_classes]; num_classes++) {
+            if (!CFCClass_included(classes[num_classes])) { all_included = 0; }
+        }
+        INT_EQ(test, num_classes, 4, "4 classes in parcel Animal");
+        OK(test, all_included, "All classes included");
+
         CFCBase_decref((CFCBase*)hierarchy);
         CFCClass_clear_registry();
         CFCParcel_reap_singletons();
@@ -214,23 +221,32 @@ S_run_include_tests(CFCTest *test) {
 
         CFCHierarchy_build(hierarchy);
 
-        CFCClass **classes    = CFCHierarchy_ordered_classes(hierarchy);
-        CFCClass  *rottweiler = NULL;;
-        int num_classes;
-        for (num_classes = 0; classes[num_classes]; ++num_classes) {
-            CFCClass *klass = classes[num_classes];
-            const char *class_name = CFCClass_get_name(klass);
-            if (strcmp(class_name, "Animal::Rottweiler") == 0) {
-                rottweiler = klass;
-            }
-            OK(test, !CFCClass_included(klass), "not included");
-        }
-        INT_EQ(test, num_classes, 5, "class count");
-        OK(test, rottweiler != NULL, "found rottweiler");
-        STR_EQ(test, CFCClass_get_name(CFCClass_get_parent(rottweiler)),
-               "Animal::Dog", "parent of class from second source");
+        CFCParcel *parcel;
+        CFCClass **classes;
 
-        FREEMEM(classes);
+        parcel = CFCParcel_fetch("AnimalExtension");
+        OK(test, parcel != NULL, "Fetch parcel AnimalExtension");
+        classes = CFCParcel_get_classes(parcel);
+        STR_EQ(test, CFCClass_get_name(classes[0]), "Animal::Rottweiler",
+               "classes[0]");
+        OK(test, !CFCClass_included(classes[0]), "not included");
+        OK(test, classes[1] == NULL, "classes[1]");
+        STR_EQ(test, CFCClass_get_name(CFCClass_get_parent(classes[0])),
+               "Animal::Dog", "parent from different parcel");
+
+        parcel = CFCParcel_fetch("Animal");
+        OK(test, parcel != NULL, "Fetch parcel Animal");
+        classes = CFCParcel_get_classes(parcel);
+        int all_not_included = 1;
+        int num_classes;
+        for (num_classes = 0; classes[num_classes]; num_classes++) {
+            if (CFCClass_included(classes[num_classes])) {
+                all_not_included = 0;
+            }
+        }
+        INT_EQ(test, num_classes, 4, "4 classes in parcel Animal");
+        OK(test, all_not_included, "All classes not included");
+
         CFCBase_decref((CFCBase*)hierarchy);
         CFCClass_clear_registry();
         CFCParcel_reap_singletons();

--- a/compiler/src/CFCTestMethod.c
+++ b/compiler/src/CFCTestMethod.c
@@ -205,7 +205,6 @@ S_run_basic_tests(CFCTest *test) {
     CFCBase_decref((CFCBase*)param_list);
     CFCBase_decref((CFCBase*)method);
 
-    CFCClass_clear_registry();
     CFCParcel_reap_singletons();
 }
 
@@ -245,7 +244,6 @@ S_run_parser_tests(CFCTest *test) {
     CFCBase_decref((CFCBase*)neato_parcel);
     CFCBase_decref((CFCBase*)parser);
 
-    CFCClass_clear_registry();
     CFCParcel_reap_singletons();
 }
 
@@ -288,7 +286,6 @@ S_run_overridden_tests(CFCTest *test) {
     CFCBase_decref((CFCBase*)overrider_param_list);
     CFCBase_decref((CFCBase*)overrider);
 
-    CFCClass_clear_registry();
     CFCParcel_reap_singletons();
 }
 
@@ -337,7 +334,6 @@ S_run_final_tests(CFCTest *test) {
     CFCBase_decref((CFCBase*)not_final);
     CFCBase_decref((CFCBase*)final);
 
-    CFCClass_clear_registry();
     CFCParcel_reap_singletons();
 }
 

--- a/compiler/src/CFCTestMethod.c
+++ b/compiler/src/CFCTestMethod.c
@@ -28,6 +28,11 @@
 #include "CFCType.h"
 #include "CFCUtil.h"
 
+#ifndef true
+  #define true 1
+  #define false 0
+#endif
+
 static void
 S_run_tests(CFCTest *test);
 
@@ -225,7 +230,10 @@ S_run_parser_tests(CFCTest *test) {
     CFCParser *parser = CFCParser_new();
     CFCParcel *neato_parcel
         = CFCTest_parse_parcel(test, parser, "parcel Neato;");
-    CFCParser_set_class_name(parser, "Neato::Obj");
+    CFCClass *neato_obj
+        = CFCClass_create(neato_parcel, NULL, "Neato::Obj", NULL, NULL, NULL,
+                          NULL, false, false, false);
+    CFCParser_set_class(parser, neato_obj);
 
     {
         static const char *method_strings[4] = {
@@ -249,6 +257,7 @@ S_run_parser_tests(CFCTest *test) {
         CFCBase_decref((CFCBase*)method);
     }
 
+    CFCBase_decref((CFCBase*)neato_obj);
     CFCBase_decref((CFCBase*)neato_parcel);
     CFCBase_decref((CFCBase*)parser);
 

--- a/compiler/src/CFCTestParamList.c
+++ b/compiler/src/CFCTestParamList.c
@@ -89,7 +89,6 @@ S_run_tests(CFCTest *test) {
     CFCBase_decref((CFCBase*)neato_parcel);
     CFCBase_decref((CFCBase*)obj_class);
 
-    CFCClass_clear_registry();
     CFCParcel_reap_singletons();
 }
 

--- a/compiler/src/CFCTestParcel.c
+++ b/compiler/src/CFCTestParcel.c
@@ -307,7 +307,6 @@ S_run_extended_tests(CFCTest *test) {
         CFCBase_decref((CFCBase*)cfish);
         CFCBase_decref((CFCBase*)foo_file_spec);
         CFCBase_decref((CFCBase*)foo);
-        CFCClass_clear_registry();
         CFCParcel_reap_singletons();
     }
 }

--- a/compiler/src/CFCTestParcel.c
+++ b/compiler/src/CFCTestParcel.c
@@ -20,6 +20,7 @@
 
 #define CFC_USE_TEST_MACROS
 #include "CFCBase.h"
+#include "CFCClass.h"
 #include "CFCFileSpec.h"
 #include "CFCParcel.h"
 #include "CFCSymbol.h"
@@ -278,9 +279,16 @@ S_run_extended_tests(CFCTest *test) {
         OK(test, CFCParcel_has_prereq(crust, crust), "has_prereq self");
         OK(test, !CFCParcel_has_prereq(crust, foo), "has_prereq false");
 
-        CFCParcel_add_struct_sym(cfish, "Swim");
-        CFCParcel_add_struct_sym(crust, "Pinch");
-        CFCParcel_add_struct_sym(foo, "Bar");
+        CFCClass *swim
+            = CFCClass_create(cfish, NULL, "Clownfish::Swim", NULL, NULL,
+                              cfish_file_spec, "Clownfish::Obj", false, false,
+                              false);
+        CFCClass *pinch
+            = CFCClass_create(crust, NULL, "Crustacean::Pinch", NULL, NULL,
+                              NULL, "Clownfish::Obj", false, false, false);
+        CFCClass *bar
+            = CFCClass_create(foo, NULL, "Foo::Bar", NULL, NULL, foo_file_spec,
+                              "Clownfish::Obj", false, false, false);
         CFCParcel *found;
         found = CFCParcel_lookup_struct_sym(crust, "Swim");
         OK(test, found == cfish, "lookup_struct_sym prereq");
@@ -290,12 +298,16 @@ S_run_extended_tests(CFCTest *test) {
         OK(test, found == NULL, "lookup_struct_sym other");
 
         FREEMEM(prereq_parcels);
+        CFCBase_decref((CFCBase*)bar);
+        CFCBase_decref((CFCBase*)pinch);
+        CFCBase_decref((CFCBase*)swim);
         CFCBase_decref((CFCBase*)crust);
         CFCBase_decref((CFCBase*)cfish_version);
         CFCBase_decref((CFCBase*)cfish_file_spec);
         CFCBase_decref((CFCBase*)cfish);
         CFCBase_decref((CFCBase*)foo_file_spec);
         CFCBase_decref((CFCBase*)foo);
+        CFCClass_clear_registry();
         CFCParcel_reap_singletons();
     }
 }

--- a/compiler/src/CFCTestParcel.c
+++ b/compiler/src/CFCTestParcel.c
@@ -47,7 +47,7 @@ S_run_extended_tests(CFCTest *test);
 
 const CFCTestBatch CFCTEST_BATCH_PARCEL = {
     "Clownfish::CFC::Model::Parcel",
-    41,
+    39,
     S_run_tests
 };
 
@@ -151,16 +151,6 @@ S_run_basic_tests(CFCTest *test) {
                "all_parcels returns parcel Foo");
         STR_EQ(test, CFCParcel_get_name(all_parcels[1]), "IncludedFoo",
                "all_parcels returns parcel IncludedFoo");
-    }
-
-    {
-        CFCParcel_add_inherited_parcel(foo, included_foo);
-        CFCParcel **inh_parcels = CFCParcel_inherited_parcels(foo);
-        OK(test, inh_parcels[0] && !inh_parcels[1],
-           "inherited_parcels returns one parcel");
-        STR_EQ(test, CFCParcel_get_name(inh_parcels[0]), "IncludedFoo",
-               "inh_parcels returns parcel IncludedFoo");
-        FREEMEM(inh_parcels);
     }
 
     CFCBase_decref((CFCBase*)included_foo);

--- a/compiler/src/CFCTestParcel.c
+++ b/compiler/src/CFCTestParcel.c
@@ -289,13 +289,13 @@ S_run_extended_tests(CFCTest *test) {
         CFCClass *bar
             = CFCClass_create(foo, NULL, "Foo::Bar", NULL, NULL, foo_file_spec,
                               "Clownfish::Obj", false, false, false);
-        CFCParcel *found;
-        found = CFCParcel_lookup_struct_sym(crust, "Swim");
-        OK(test, found == cfish, "lookup_struct_sym prereq");
-        found = CFCParcel_lookup_struct_sym(crust, "Pinch");
-        OK(test, found == crust, "lookup_struct_sym self");
-        found = CFCParcel_lookup_struct_sym(crust, "Bar");
-        OK(test, found == NULL, "lookup_struct_sym other");
+        CFCClass *klass;
+        klass = CFCParcel_class_by_short_sym(crust, "Swim");
+        OK(test, klass == swim, "class_by_short_sym prereq");
+        klass = CFCParcel_class_by_short_sym(crust, "Pinch");
+        OK(test, klass == pinch, "class_by_short_sym self");
+        klass = CFCParcel_class_by_short_sym(crust, "Bar");
+        OK(test, klass == NULL, "class_by_short_sym other");
 
         FREEMEM(prereq_parcels);
         CFCBase_decref((CFCBase*)bar);

--- a/compiler/src/CFCTestParser.c
+++ b/compiler/src/CFCTestParser.c
@@ -137,7 +137,6 @@ S_run_tests(CFCTest *test) {
         for (int i = 0; i < 7; ++i) {
             CFCBase_decref((CFCBase*)class_list[i]);
         }
-        CFCClass_clear_registry();
     }
 
     {
@@ -316,7 +315,6 @@ S_run_tests(CFCTest *test) {
 
     CFCBase_decref((CFCBase*)parser);
 
-    CFCClass_clear_registry();
     CFCParcel_reap_singletons();
 }
 

--- a/compiler/src/CFCTestParser.c
+++ b/compiler/src/CFCTestParser.c
@@ -42,7 +42,7 @@ S_test_initial_value(CFCTest *test, CFCParser *parser,
 
 const CFCTestBatch CFCTEST_BATCH_PARSER = {
     "Clownfish::CFC::Model::Parser",
-    203,
+    205,
     S_run_tests
 };
 
@@ -261,7 +261,11 @@ S_run_tests(CFCTest *test) {
     }
 
     {
-        CFCParser_set_class_name(parser, "Stuff::Obj");
+        CFCParcel *stuff = CFCTest_parse_parcel(test, parser, "parcel Stuff;");
+        CFCClass *stuff_obj
+            = CFCClass_create(stuff, NULL, "Stuff::Obj", NULL, NULL, NULL,
+                              NULL, false, false, false);
+        CFCParser_set_class(parser, stuff_obj);
 
         const char *method_string =
             "public Foo* Spew_Foo(Obj *self, uint32_t *how_many);";
@@ -272,6 +276,9 @@ S_run_tests(CFCTest *test) {
             "public inert Hash *hash;";
         CFCVariable *var = CFCTest_parse_variable(test, parser, var_string);
         CFCBase_decref((CFCBase*)var);
+
+        CFCBase_decref((CFCBase*)stuff_obj);
+        CFCBase_decref((CFCBase*)stuff);
     }
 
     {

--- a/compiler/src/CFCTestParser.c
+++ b/compiler/src/CFCTestParser.c
@@ -276,8 +276,8 @@ S_run_tests(CFCTest *test) {
 
     {
         static const char *const class_names[4] = {
-            "Foo", "Foo::FooJr", "Foo::FooJr::FooIII",
-            "Foo::FooJr::FooIII::Foo4th"
+            "Moo", "Moo::MooJr", "Moo::MooJr::MooIII",
+            "Moo::MooJr::MooIII::Moo4th"
         };
         for (int i = 0; i < 4; ++i) {
             const char *class_name = class_names[i];

--- a/compiler/src/CFCTestType.c
+++ b/compiler/src/CFCTestType.c
@@ -337,7 +337,6 @@ S_run_object_tests(CFCTest *test) {
             }
 
             CFCBase_decref((CFCBase*)klass);
-            CFCClass_clear_registry();
         }
 
         CFCBase_decref((CFCBase*)neato_parcel);
@@ -441,7 +440,6 @@ S_run_object_tests(CFCTest *test) {
     CFCBase_decref((CFCBase*)foo_class);
     CFCBase_decref((CFCBase*)foo);
 
-    CFCClass_clear_registry();
     CFCParcel_reap_singletons();
 }
 

--- a/compiler/src/CFCTestVariable.c
+++ b/compiler/src/CFCTestVariable.c
@@ -139,7 +139,6 @@ S_run_tests(CFCTest *test) {
     CFCBase_decref((CFCBase*)neato_parcel);
     CFCBase_decref((CFCBase*)foo_class);
 
-    CFCClass_clear_registry();
     CFCParcel_reap_singletons();
 }
 

--- a/compiler/src/CFCType.c
+++ b/compiler/src/CFCType.c
@@ -35,9 +35,9 @@ struct CFCType {
     CFCBase  base;
     int      flags;
     char    *specifier;
-    char    *class_var;
     int      indirection;
     CFCWeakPtr parcel;
+    CFCWeakPtr klass;
     char    *c_string;
     size_t   width;
     char    *array;
@@ -99,7 +99,6 @@ CFCType_init(CFCType *self, int flags, struct CFCParcel *parcel,
     self->width       = 0;
     self->array       = NULL;
     self->child       = NULL;
-    self->class_var   = NULL;
 
     return self;
 }
@@ -300,6 +299,7 @@ CFCType_resolve(CFCType *self) {
         if (!klass) {
             CFCUtil_die("No class found for type '%s'", specifier);
         }
+        CFCWeakPtr_set(&self->klass, (CFCBase*)klass);
 
         // Upgrade specifier to full struct sym.
         self->specifier = CFCUtil_strdup(CFCClass_full_struct_sym(klass));
@@ -313,10 +313,10 @@ CFCType_destroy(CFCType *self) {
         CFCBase_decref((CFCBase*)self->child);
     }
     CFCWeakPtr_destroy(&self->parcel);
+    CFCWeakPtr_destroy(&self->klass);
     FREEMEM(self->specifier);
     FREEMEM(self->c_string);
     FREEMEM(self->array);
-    FREEMEM(self->class_var);
     CFCBase_destroy((CFCBase*)self);
 }
 
@@ -377,15 +377,13 @@ CFCType_get_specifier(CFCType *self) {
     return self->specifier;
 }
 
-const char*
-CFCType_get_class_var(CFCType *self) {
-    if (!self->class_var) {
-        self->class_var = CFCUtil_strdup(self->specifier);
-        for (int i = 0; self->class_var[i] != 0; i++) {
-            self->class_var[i] = CFCUtil_toupper(self->class_var[i]);
-        }
+CFCClass*
+CFCType_get_class(CFCType *self) {
+    CFCClass *klass = (CFCClass*)CFCWeakPtr_deref(self->klass);
+    if (!klass) {
+        CFCUtil_die("Type has no class");
     }
-    return self->class_var;
+    return klass;
 }
 
 int

--- a/compiler/src/CFCType.c
+++ b/compiler/src/CFCType.c
@@ -295,16 +295,14 @@ CFCType_resolve(CFCType *self) {
 
     char *specifier = self->specifier;
     if (CFCUtil_isupper(specifier[0])) {
-        CFCParcel *src_parcel = CFCType_get_parcel(self);
-        CFCParcel *parcel
-            = CFCParcel_lookup_struct_sym(src_parcel, specifier);
-        if (!parcel) {
+        CFCParcel *parcel = CFCType_get_parcel(self);
+        CFCClass  *klass  = CFCParcel_class_by_short_sym(parcel, specifier);
+        if (!klass) {
             CFCUtil_die("No class found for type '%s'", specifier);
         }
 
-        // Create actual specifier with prefix.
-        const char *prefix = CFCParcel_get_prefix(parcel);
-        self->specifier = CFCUtil_sprintf("%s%s", prefix, specifier);
+        // Upgrade specifier to full struct sym.
+        self->specifier = CFCUtil_strdup(CFCClass_full_struct_sym(klass));
         FREEMEM(specifier);
     }
 }

--- a/compiler/src/CFCType.h
+++ b/compiler/src/CFCType.h
@@ -203,11 +203,10 @@ CFCType_set_specifier(CFCType *self, const char *specifier);
 const char*
 CFCType_get_specifier(CFCType *self);
 
-/** Return the name of the Class variable which corresponds to the object
- * type.  Returns NULL for non-object types.
+/** Return the Class object which corresponds to the object type.
  */
-const char*
-CFCType_get_class_var(CFCType *self);
+struct CFCClass*
+CFCType_get_class(CFCType *self);
 
 int
 CFCType_get_indirection(CFCType *self);


### PR DESCRIPTION
- Move the class registry and the class array in CFCHierarchy to CFCParcel.
- Introduce CFCWeakPtr to safely work with circular references.
- Add CFCType_get_class.
- Improve URI resolution.
- Minor cleanups.
