### PR TITLE
Allow Perl subclasses to use hashrefs

### DIFF
--- a/compiler/src/CFCBindCore.c
+++ b/compiler/src/CFCBindCore.c
@@ -199,6 +199,12 @@ S_write_parcel_h(CFCBindCore *self, CFCParcel *parcel) {
         "   void *klass;\n"
         "} cfish_Dummy;\n"
         "\n"
+        "typedef struct cfish_HostObjWrapper {\n"
+        "   CFISH_OBJ_HEAD\n"
+        "   void *klass;\n"
+        "   void *wrapped;\n"
+        "} cfish_HostObjWrapper;\n"
+        "\n"
         "/* Access the function pointer for a given method from the object.\n"
         " */\n"
         "static CFISH_INLINE cfish_method_t\n"
@@ -287,6 +293,8 @@ S_write_parcel_h(CFCBindCore *self, CFCParcel *parcel) {
         "/* Flags for internal use. */\n"
         "#define CFISH_fREFCOUNTSPECIAL 0x00000001\n"
         "#define CFISH_fFINAL           0x00000002\n"
+        "#define CFISH_fEMPTY           0x00000004\n"
+        "#define CFISH_fHOST            0x00000008\n"
         ;
     const char *cfish_defs_2 =
         "#ifdef CFISH_USE_SHORT_NAMES\n"

--- a/runtime/c/src/clownfish.c
+++ b/runtime/c/src/clownfish.c
@@ -165,6 +165,11 @@ Class_find_parent_class(String *class_name) {
     UNREACHABLE_RETURN(String*);
 }
 
+void
+Class_adjust_host_subclass(Class *klass) {
+    UNUSED_VAR(klass);
+}
+
 /**** Method ***************************************************************/
 
 String*

--- a/runtime/core/Clownfish/Class.cfh
+++ b/runtime/core/Clownfish/Class.cfh
@@ -90,6 +90,11 @@ public final class Clownfish::Class inherits Clownfish::Obj {
     inert incremented Vector*
     fresh_host_methods(String *class_name);
 
+    /** Perform final adjustments to a host subclass.
+     */
+    inert void
+    adjust_host_subclass(Class *klass);
+
     /** Replace a function pointer in the Class's vtable.
      */
     public void

--- a/runtime/go/ext/clownfish.c
+++ b/runtime/go/ext/clownfish.c
@@ -169,6 +169,11 @@ Class_find_parent_class(String *class_name) {
     UNREACHABLE_RETURN(String*);
 }
 
+void
+Class_adjust_host_subclass(Class *klass) {
+    UNUSED_VAR(klass);
+}
+
 void*
 Class_To_Host_IMP(Class *self, void *vcache) {
     UNUSED_VAR(self);

--- a/runtime/perl/t/binding/010-class.t
+++ b/runtime/perl/t/binding/010-class.t
@@ -30,7 +30,7 @@ my $storage = Clownfish::Hash->new;
 
 {
     my $subclassed_obj = MyObj->new;
-    $stringified = $subclassed_obj->to_string;
+    $stringified = "$subclassed_obj";
 
     isa_ok( $subclassed_obj, "MyObj", "Perl isa reports correct subclass" );
 
@@ -43,12 +43,13 @@ my $storage = Clownfish::Hash->new;
 my $resurrected = $storage->fetch("test");
 
 isa_ok( $resurrected, "MyObj", "subclass name survived Perl destruction" );
-is( $resurrected->to_string, $stringified,
-    "It's the same Hash from earlier (though a different Perl object)" );
+is( "$resurrected", $stringified, "It's the same hashref from earlier" );
 
 is( $resurrected->get_class_name,
     "MyObj", "subclassed object still performs correctly at the C level" );
 
-my $methods = Clownfish::Class::_fresh_host_methods('MyObj');
-is_deeply( $methods->to_perl, ['oodle'], "fresh_host_methods" );
+my $methods = Clownfish::Class::_fresh_host_methods('MyObj')->to_perl;
+# Remove overload methods starting with '('.
+$methods = [ grep { $_ !~ /^\(/ } @$methods ];
+is_deeply( $methods, ['oodle'], "fresh_host_methods" );
 

--- a/runtime/perl/xs/XSBind.h
+++ b/runtime/perl/xs/XSBind.h
@@ -222,6 +222,11 @@ cfish_XSBind_bootstrap(pTHX_ size_t num_classes,
                        const cfish_XSBind_XSubSpec *xsub_specs,
                        const char *file);
 
+/** Destroy a Clownfish SV.
+ */
+CFISH_VISIBLE void
+cfish_XSBind_destroy(pTHX_ SV *sv);
+
 #define XSBIND_PARAM(key, required) \
     { key, (int16_t)sizeof("" key) - 1, (char)required }
 
@@ -252,6 +257,7 @@ cfish_XSBind_bootstrap(pTHX_ size_t num_classes,
 #define XSBind_invalid_args_error      cfish_XSBind_invalid_args_error
 #define XSBind_undef_arg_error         cfish_XSBind_undef_arg_error
 #define XSBind_bootstrap               cfish_XSBind_bootstrap
+#define XSBind_destroy                 cfish_XSBind_destroy
 
 /* Strip the prefix from some common ClownFish symbols where we know there's
  * no conflict with Perl.  It's a little inconsistent to do this rather than

--- a/runtime/python/cfext/CFBind.c
+++ b/runtime/python/cfext/CFBind.c
@@ -992,6 +992,11 @@ cfish_Class_find_parent_class(cfish_String *class_name) {
     return NULL;
 }
 
+void
+cfish_Class_adjust_host_subclass(cfish_Class *klass) {
+    CFISH_UNUSED_VAR(klass);
+}
+
 /**** Method ***************************************************************/
 
 cfish_String*

--- a/runtime/test/Clownfish/Test/TestHost.c
+++ b/runtime/test/Clownfish/Test/TestHost.c
@@ -23,7 +23,31 @@
 
 TestHost*
 TestHost_new() {
-    return (TestHost*)Class_Make_Obj(TESTHOST);
+    TestHost *self = (TestHost*)Class_Make_Obj(TESTHOST);
+    return TestHost_init(self);
+}
+
+TestHost*
+TestHost_init(TestHost *self) {
+    Obj_init((Obj*)self);
+    TestHost_Do_Init(self);
+    return self;
+}
+
+void
+TestHost_Do_Init_IMP(TestHost *self) {
+    UNUSED_VAR(self);
+}
+
+void
+TestHost_Destroy_IMP(TestHost *self) {
+    TestHost_Do_Destroy(self);
+    SUPER_DESTROY(self, TESTHOST);
+}
+
+void
+TestHost_Do_Destroy_IMP(TestHost *self) {
+    UNUSED_VAR(self);
 }
 
 Obj*

--- a/runtime/test/Clownfish/Test/TestHost.cfh
+++ b/runtime/test/Clownfish/Test/TestHost.cfh
@@ -22,6 +22,16 @@ class Clownfish::Test::TestHost {
     inert incremented TestHost*
     new();
 
+    /** Invokes the (possibly overridden) method [](.Do_Init).
+     */
+    inert TestHost*
+    init(TestHost *self);
+
+    /** Called from constructor.
+     */
+    void
+    Do_Init(TestHost *self);
+
     Obj*
     Test_Obj_Pos_Arg(TestHost *self, Obj *arg);
 
@@ -76,6 +86,17 @@ class Clownfish::Test::TestHost {
 
     incremented String*
     Invoke_Aliased_From_C(TestHost* self);
+
+    /** A destructor that invokes the (possibly overridden) method
+     * [](.Do_Destroy).
+     */
+    public void
+    Destroy(TestHost* self);
+
+    /** Called from destructor.
+     */
+    void
+    Do_Destroy(TestHost *self);
 }
 
 


### PR DESCRIPTION
If a parent class without ivars is subclassed from Perl, don't store
the pointer to the Clownfish object in the SV, but use a hashref as
underlying Perl object. This allows Perl subclasses to store their own
ivars directly in the hashref without having to resort to inside-out
objects.

This requires to create a host object wrapper whenever an object is
constructed or a Clownfish method is invoked. A similar approach can
be used by other host languages without class-based inheritance.

The perl_to_cfish functions now use Class_fetch and an is_a check based
on the Clownfish parent class pointer instead of calling sv_derived_from.
I haven't checked whether there's a performance impact, but this might
actually be faster than the old code.

The old inside-out approach is still supported by overloading scalar
dereferencing for host object wrappers.